### PR TITLE
(feat) move exec type field config to inline

### DIFF
--- a/config/executables.go
+++ b/config/executables.go
@@ -165,7 +165,7 @@ type Executable struct {
 	Timeout     time.Duration `yaml:"timeout,omitempty"`
 	// +docsgen:typeExec
 	// The type of executable. Only one type can be set.
-	Type *ExecutableTypeSpec `yaml:"type,omitempty"`
+	Type *ExecutableTypeSpec `yaml:",inline,omitempty"`
 
 	workspace, namespace, workspacePath, definitionPath string
 }

--- a/dev.flow
+++ b/dev.flow
@@ -8,8 +8,7 @@ executables:
     aliases:
       - pc
     description: Run the repo's pre-commit script
-    type:
-      exec:
-        dir: //
-        cmd: |
-          make pre-commit
+    exec:
+      dir: //
+      cmd: |
+        make pre-commit

--- a/docs/config/executables.md
+++ b/docs/config/executables.md
@@ -83,26 +83,125 @@ The visibility of the executables to Flow.<br>If not set, the visibility will de
 | tags | Array (string) | A list of tags.<br>Tags can be used with list commands to filter returned data. |
 | description | String |  |
 | visibility | [Visibility](#Visibility) |  |
-| type | [ExecutableTypeSpec](#ExecutableTypeSpec) |  |
-
-
--------
-## ExecutableTypeSpec
-
-**Type**: Object
-
-
-
-### Fields
-
-| Key | Type | Description |
-| ---- | ---- | ----------- |
 | exec | [ExecExecutableType](#ExecExecutableType) |  |
 | launch | [LaunchExecutableType](#LaunchExecutableType) |  |
 | request | [RequestExecutableType](#RequestExecutableType) |  |
 | render | [RenderExecutableType](#RenderExecutableType) |  |
 | serial | [SerialExecutableType](#SerialExecutableType) |  |
 | parallel | [ParallelExecutableType](#ParallelExecutableType) |  |
+
+
+-------
+## ExecExecutableType
+
+**Type**: Object
+
+Standard executable type. Runs a command/file in a subprocess.
+
+### Fields
+
+| Key | Type | Description |
+| ---- | ---- | ----------- |
+| dir | String | The directory to execute the command in.<br>If unset, the directory of the executable definition will be used.<br>If set to `f:tmp`, a temporary directory will be created for the process.<br>If prefixed with `./`, the path will be relative to the current working directory.<br>If prefixed with `//`, the path will be relative to the workspace root.<br>Environment variables in the path will be expended at runtime. |
+| params | Array ([Parameter](#Parameter)) | List of parameters to pass to the executable. |
+| args | Array ([Argument](#Argument)) |  |
+| cmd | String |  |
+| file | String |  |
+| logMode | [LogMode](#LogMode) |  |
+
+
+-------
+## LaunchExecutableType
+
+**Type**: Object
+
+Launches an application or opens a URI.
+
+### Fields
+
+| Key | Type | Description |
+| ---- | ---- | ----------- |
+| params | Array ([Parameter](#Parameter)) | List of parameters to pass to the executable. |
+| args | Array ([Argument](#Argument)) |  |
+| app | String |  |
+| uri | String |  |
+| wait | Boolean |  |
+
+
+-------
+## ParallelExecutableType
+
+**Type**: Object
+
+Runs a list of executables in parallel.
+
+### Fields
+
+| Key | Type | Description |
+| ---- | ---- | ----------- |
+| params | Array ([Parameter](#Parameter)) | List of parameters to pass to the executable. |
+| args | Array ([Argument](#Argument)) |  |
+| refs | Array ([Ref](#Ref)) | List of executables references |
+| maxThreads | Integer |  |
+| failFast | Boolean |  |
+
+
+-------
+## RenderExecutableType
+
+**Type**: Object
+
+Renders a Markdown template with provided data. Requires the Interactive UI.
+
+### Fields
+
+| Key | Type | Description |
+| ---- | ---- | ----------- |
+| dir | String | The directory to execute the command in.<br>If unset, the directory of the executable definition will be used.<br>If set to `f:tmp`, a temporary directory will be created for the process.<br>If prefixed with `./`, the path will be relative to the current working directory.<br>If prefixed with `//`, the path will be relative to the workspace root.<br>Environment variables in the path will be expended at runtime. |
+| params | Array ([Parameter](#Parameter)) | List of parameters to pass to the executable. |
+| args | Array ([Argument](#Argument)) |  |
+| templateFile | String |  |
+| templateDataFile | String |  |
+
+
+-------
+## RequestExecutableType
+
+**Type**: Object
+
+Makes an HTTP request.
+
+### Fields
+
+| Key | Type | Description |
+| ---- | ---- | ----------- |
+| params | Array ([Parameter](#Parameter)) | List of parameters to pass to the executable. |
+| args | Array ([Argument](#Argument)) |  |
+| method | String |  |
+| url | String |  |
+| body | String |  |
+| headers | Map (string -> string) |  |
+| responseFile | [RequestResponseFile](#RequestResponseFile) |  |
+| transformResponse | String |  |
+| logResponse | Boolean |  |
+| validStatusCodes | Array (int) |  |
+
+
+-------
+## SerialExecutableType
+
+**Type**: Object
+
+Runs a list of executables in serial.
+
+### Fields
+
+| Key | Type | Description |
+| ---- | ---- | ----------- |
+| params | Array ([Parameter](#Parameter)) | List of parameters to pass to the executable. |
+| args | Array ([Argument](#Argument)) |  |
+| refs | Array ([Ref](#Ref)) | List of executables references |
+| failFast | Boolean |  |
 
 
 -------

--- a/docs/docs.flow
+++ b/docs/docs.flow
@@ -9,36 +9,32 @@ executables:
     aliases:
       - generate
     description: Generate the Flow documentation from the source code
-    type:
-      exec:
-        dir: //
-        cmd: |
-          go run ./tools/docsgen/main.go
+    exec:
+      dir: //
+      cmd: |
+        go run ./tools/docsgen/main.go
   - verb: show
     name: execs
     aliases:
       - executables
       - exec
     description: Render the Flow Executable reference documentation
-    type:
-      render:
-        dir: config
-        templateFile: executables.md
+    render:
+      dir: config
+      templateFile: executables.md
   - verb: show
     name: ws
     aliases:
       - workspaces
     description: Render the Flow Workspace reference documentation
-    type:
-      render:
-        dir: config
-        templateFile: workspace_config.md
+    render:
+      dir: config
+      templateFile: workspace_config.md
   - verb: show
     name: cfg
     aliases:
       - user-config
     description: Render the Flow User Config reference documentation
-    type:
-      render:
-        dir: config
-        templateFile: user_config.md
+    render:
+      dir: config
+      templateFile: user_config.md

--- a/tests/testdata/debugging.flow
+++ b/tests/testdata/debugging.flow
@@ -6,9 +6,8 @@ executables:
   - verb: run
     name: shell-input
     description: Accept user input from the shell
-    type:
-      exec:
-        cmd: |
-            echo "Enter your name:"
-            read name
-            echo "Hello, $name!"
+    exec:
+      cmd: |
+          echo "Enter your name:"
+          read name
+          echo "Hello, $name!"

--- a/tests/testdata/happy-path.flow
+++ b/tests/testdata/happy-path.flow
@@ -8,94 +8,86 @@ executables:
     aliases:
       - ip
     description: Print a simple message from an inline exec definition
-    type:
-      exec:
-        cmd: |
-          echo "Hello from an inline definition!"
+    exec:
+      cmd: |
+        echo "Hello from an inline definition!"
   - verb: run
     name: file-print
     aliases:
       - fp
     description: Print a simple message from a file exec definition
-    type:
-      exec:
-        file: hello.sh
-        params:
-          - text: flow
-            envKey: NAME
+    exec:
+      file: hello.sh
+      params:
+        - text: flow
+          envKey: NAME
   - verb: start
     name: serial-print
     aliases:
       - sp
     description: Print a series of messages from a serial exec definition
-    type:
-      serial:
-        refs:
-          - run tests:inline-print
-          - run tests:file-print
+    serial:
+      refs:
+        - run tests:inline-print
+        - run tests:file-print
   - verb: start
     name: parallel-print
     aliases:
       - pp
     description: Print a messages in parallel from a parallel exec definition
-    type:
-      parallel:
-        refs:
-          - run tests:inline-print
-          - run tests:file-print
+    parallel:
+      refs:
+        - run tests:inline-print
+        - run tests:file-print
   - verb: run
     name: simple-request
     description: Send a simple REST request
-    type:
-      request:
-        method: POST
-        url: https://httpbin.org/post
-        headers:
-          Content-Type: application/json
-        body: '{"hello": "world"}'
-        logResponse: true
-        validStatusCodes:
-          - 200
+    request:
+      method: POST
+      url: https://httpbin.org/post
+      headers:
+        Content-Type: application/json
+      body: '{"hello": "world"}'
+      logResponse: true
+      validStatusCodes:
+        - 200
   - verb: show
     name: welcome
     description: Render an example markdown template
-    type:
-      render:
-        templateFile: template.md
-        templateDataFile: template-data.yaml
-        params:
-          - prompt: What is your name?
-            envKey: NAME
-          - text: Hi
-            envKey: GREETING
+    render:
+      templateFile: template.md
+      templateDataFile: template-data.yaml
+      params:
+        - prompt: What is your name?
+          envKey: NAME
+        - text: Hi
+          envKey: GREETING
   - verb: run
     name: secret-printer
     description: |
       Print a secret stored in the vault.
       This required the flowTestSecret to be set in the vault.
-    type:
-      exec:
-        cmd: |
-          echo "Value: ${TEST_SECRET}"
-        params:
-          - secretRef: flowTestSecret
-            envKey: TEST_SECRET
+    exec:
+      cmd: |
+        echo "Value: ${TEST_SECRET}"
+      params:
+        - secretRef: flowTestSecret
+          envKey: TEST_SECRET
   - verb: run
     name: arg-echo
     description: |
       Echo the value of the provided arguments
-    type:
-      exec:
-        cmd: |
-          echo "Arg1: $TEST_ARG1, Arg2: $TEST_ARG2, Arg3: $TEST_ARG3"
-        args:
-          - envKey: TEST_ARG1
-            pos: 1
-            required: true
-          - envKey: TEST_ARG2
-            pos: 2
-            required: false
-            default: "green"
-          - envKey: TEST_ARG3
-            flag: arg3
-            default: "grape"
+    exec:
+      cmd: |
+        echo "Arg1: $TEST_ARG1, Arg2: $TEST_ARG2, Arg3: $TEST_ARG3"
+      args:
+        - envKey: TEST_ARG1
+          pos: 1
+          required: true
+        - envKey: TEST_ARG2
+          pos: 2
+          required: false
+          default: "green"
+        - envKey: TEST_ARG3
+          flag: arg3
+          default: "grape"

--- a/tests/testdata/sample.flow.tmpl
+++ b/tests/testdata/sample.flow.tmpl
@@ -13,6 +13,5 @@ executables:
   - verb: run
     name: "{{ .Color }}-msg"
     description: Created from a template in {{ .Workspace }}
-    type:
-      exec:
-        cmd: cat message.txt
+    exec:
+      cmd: cat message.txt


### PR DESCRIPTION
# Summary

This is a breaking change that removed the `type` field from the exec configurations. Instead, the exec type can be defined inline. This change was made to make configuring simpler

## Notable Changes

- `type` exec field is now an inline field and does not need to be specified in yaml

## Change Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
