### PR TITLE
(feat) run executables from interactive views

### DIFF
--- a/cmd/internal/interactive/interactive.go
+++ b/cmd/internal/interactive/interactive.go
@@ -27,8 +27,7 @@ func UIEnabled(ctx *context.Context, cmd *cobra.Command) bool {
 
 func InitInteractiveCommand(ctx *context.Context, cmd *cobra.Command) {
 	if UIEnabled(ctx, cmd) {
-		_, _ = fmt.Fprintln(ctx.StdOut(), io.Theme().
-			RenderHeader(appName, headerCtxKey, headerCtxVal(ctx), 0))
+		ctx.Logger.Println(io.Theme().RenderHeader(appName, headerCtxKey, headerCtxVal(ctx), 0))
 	}
 }
 

--- a/cmd/internal/list.go
+++ b/cmd/internal/list.go
@@ -128,10 +128,12 @@ func listExecutableFunc(ctx *context.Context, cmd *cobra.Command, _ []string) {
 		FilterBySubstring(substr)
 
 	if interactive.UIEnabled(ctx, cmd) {
+		runFunc := func(ref string) error { return runByRef(ctx, cmd, ref) }
 		view := executableio.NewExecutableListView(
 			ctx,
 			filteredExec,
 			components.Format(outputFormat),
+			runFunc,
 		)
 		ctx.InteractiveContainer.SetView(view)
 	} else {

--- a/config/executables.go
+++ b/config/executables.go
@@ -399,6 +399,7 @@ func (l ExecutableList) Items() []*types.CollectionItem {
 		item := &types.CollectionItem{
 			Header: exec.Ref().String(),
 			Desc:   exec.Description,
+			ID:     exec.Ref().String(),
 		}
 		if len(exec.Tags) > 0 {
 			item.Desc = fmt.Sprintf("[%s]\n", exec.Tags.PreviewString()) + exec.Description

--- a/config/workspace_config.go
+++ b/config/workspace_config.go
@@ -157,6 +157,7 @@ func (l WorkspaceConfigList) Items() []*types.CollectionItem {
 			Header:    name,
 			SubHeader: location,
 			Desc:      ws.Description,
+			ID:        name,
 		}
 		items = append(items, &item)
 	}

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/gen2brain/beeep v0.0.0-20240112042604-c7bb2cd88fea
 	github.com/itchyny/gojq v0.12.15
 	github.com/jahvon/open-golang v0.0.0-20240522004812-68511c3bc9ef
-	github.com/jahvon/tuikit v0.0.12
+	github.com/jahvon/tuikit v0.0.13
 	github.com/mattn/go-runewidth v0.0.15
 	github.com/onsi/ginkgo/v2 v2.17.2
 	github.com/onsi/gomega v1.33.1

--- a/go.sum
+++ b/go.sum
@@ -60,8 +60,8 @@ github.com/jahvon/glamour v0.7.1-patch1 h1:v3btiQx2OB0ETStjkXciUjwZBO9fXfSv5flZl
 github.com/jahvon/glamour v0.7.1-patch1/go.mod h1:jUMh5MeihljJPQbJ/wf4ldw2+yBP59+ctV36jASy7ps=
 github.com/jahvon/open-golang v0.0.0-20240522004812-68511c3bc9ef h1:4PS/MNVT6Rsv15x5Rtwaw971e6kFvNUAf9nvUsZ5hcc=
 github.com/jahvon/open-golang v0.0.0-20240522004812-68511c3bc9ef/go.mod h1:dUmuT5CN6osIeLSRtTPJOf0Yz+qAbcyU6omnCzI+ZfQ=
-github.com/jahvon/tuikit v0.0.12 h1:JpoZ9zESPfZ98h2gWerE3P1/LqhOFUy7Ea/loBDtiVU=
-github.com/jahvon/tuikit v0.0.12/go.mod h1:6T4MFGAy4aSlDLV5Ka1FUd+TOt/fCXBrsibRpM1I3mI=
+github.com/jahvon/tuikit v0.0.13 h1:/L9P7PGD/LiUAWFI525ShpAUeHeY7IrvNJFcD9dZ93c=
+github.com/jahvon/tuikit v0.0.13/go.mod h1:6T4MFGAy4aSlDLV5Ka1FUd+TOt/fCXBrsibRpM1I3mI=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=

--- a/internal/io/library/library.go
+++ b/internal/io/library/library.go
@@ -34,6 +34,8 @@ type Library struct {
 	currentPane, currentWorkspace, currentNamespace, currentExecutable uint
 	paneZeroViewport, paneOneViewport, paneTwoViewport                 viewport.Model
 	loadingScreen                                                      tea.Model
+
+	cmdRunFunc func(string) error
 }
 
 type Filter struct {
@@ -49,6 +51,7 @@ func NewLibrary(
 	execs config.ExecutableList,
 	filter Filter,
 	theme styles.Theme,
+	runFunc func(string) error,
 ) *Library {
 	p1 := viewport.New(0, 0)
 	p2 := viewport.New(0, 0)
@@ -65,7 +68,20 @@ func NewLibrary(
 		paneOneViewport:  p2,
 		paneTwoViewport:  p3,
 		theme:            theme,
+		cmdRunFunc:       runFunc,
 	}
+}
+
+func NewLibraryView(
+	ctx *context.Context,
+	workspaces config.WorkspaceConfigList,
+	execs config.ExecutableList,
+	filter Filter,
+	theme styles.Theme,
+	runFunc func(string) error,
+) components.TeaModel {
+	l := NewLibrary(ctx, workspaces, execs, filter, theme, runFunc)
+	return components.NewFrameView(l)
 }
 
 func ctxVal(ws, ns string) string {

--- a/internal/io/library/view.go
+++ b/internal/io/library/view.go
@@ -28,7 +28,8 @@ const (
 	helpPrefix          = "[ ↑/↓: navigate pane ] [ ←/→: change pane ]"
 	paneOneHelp         = "[ o: open ] [ e: edit ] [ s:set ] ● [ space: show namespaces ]"
 	paneOneExpandedHelp = "[ o: open ] [ e: edit ] [ s:set ] ● [ space: hide namespaces ]"
-	paneTwoAndThreeHelp = "[ e: edit ] [ c: copy ref ]  ● [ f: change format ]"
+	paneTwoHelp         = "[ r: run ] [ e: edit ] [ c: copy ref ]  ● [ f: change format ]"
+	paneThreeHelp       = "[ r: run ] [ e: edit ] [ c: copy ref ]  ● [ f: change format ]"
 )
 
 var (
@@ -214,8 +215,13 @@ func (l *Library) footerContent() string {
 		}
 	case 1, 2:
 		if help {
+			helpStr := paneTwoHelp
+			if l.currentPane == 3 {
+				helpStr = paneThreeHelp
+			}
+
 			return l.theme.RenderFooter(
-				fmt.Sprintf("%s ● %s ● %s", footerPrefix, helpPrefix, paneTwoAndThreeHelp), l.termWidth,
+				fmt.Sprintf("%s ● %s ● %s", footerPrefix, helpPrefix, helpStr), l.termWidth,
 			)
 		} else if l.currentExecutable < uint(len(l.visibleExecutables)) {
 			exec := l.visibleExecutables[l.currentExecutable]


### PR DESCRIPTION
# Summary

This pr makes it so that the `r` key can be used to run the selected executable in the library and get/list exec views.

## Notable Changes

- Small code refactoring of the library and exec command. Library is now launch as a tuikit container frame so that it can be killed 
- `r` callback keys added for the get and list exec and library commands.
- Fixed a bug with selecting executables in the list view. Now the ref is used as a consistent ID

## Change Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
