### PR TITLE
(fix) set context on generated execs

### DIFF
--- a/config/cache/executable_generator.go
+++ b/config/cache/executable_generator.go
@@ -14,7 +14,11 @@ import (
 
 const generatedTag = "generated"
 
-func generatedExecutables(logger io.Logger, definitionPath string, files []string) (config.ExecutableList, error) {
+func generatedExecutables(
+	logger io.Logger,
+	wsName, wsPath, definitionNs, definitionPath string,
+	files []string,
+) (config.ExecutableList, error) {
 	executables := make(config.ExecutableList, 0)
 	for _, file := range files {
 		shFile := filepath.Join(filepath.Dir(definitionPath), file)
@@ -22,6 +26,7 @@ func generatedExecutables(logger io.Logger, definitionPath string, files []strin
 		if err != nil {
 			return nil, err
 		}
+		executable.SetContext(wsName, wsPath, definitionNs, definitionPath)
 		executables = append(executables, executable)
 	}
 

--- a/config/cache/executables_cache.go
+++ b/config/cache/executables_cache.go
@@ -77,7 +77,14 @@ func (c *ExecutableCache) Update(logger io.Logger) error { //nolint:gocognit
 		}
 		for _, def := range definitions {
 			if len(def.FromFiles) > 0 {
-				generated, err := generatedExecutables(logger, def.DefinitionPath(), def.FromFiles)
+				generated, err := generatedExecutables(
+					logger,
+					name,
+					wsCfg.Location(),
+					def.Namespace,
+					def.DefinitionPath(),
+					def.FromFiles,
+				)
 				if err != nil {
 					logger.Errorx(
 						"failed to generate executables from files",
@@ -160,7 +167,14 @@ func (c *ExecutableCache) GetExecutableByRef(logger io.Logger, ref config.Ref) (
 	definition.SetDefaults()
 	definition.SetContext(wsInfo.WorkspaceName, wsInfo.WorkspacePath, definitionPath)
 
-	generated, err := generatedExecutables(logger, definition.DefinitionPath(), definition.FromFiles)
+	generated, err := generatedExecutables(
+		logger,
+		wsInfo.WorkspaceName,
+		wsInfo.WorkspacePath,
+		definition.Namespace,
+		definition.DefinitionPath(),
+		definition.FromFiles,
+	)
 	if err != nil {
 		logger.Warnx(
 			"failed to generate executables from files",
@@ -205,7 +219,14 @@ func (c *ExecutableCache) GetExecutableList(logger io.Logger) (config.Executable
 		definition.SetDefaults()
 		definition.SetContext(wsInfo.WorkspaceName, wsInfo.WorkspacePath, definitionPath)
 
-		generated, err := generatedExecutables(logger, definition.DefinitionPath(), definition.FromFiles)
+		generated, err := generatedExecutables(
+			logger,
+			wsInfo.WorkspaceName,
+			wsInfo.WorkspacePath,
+			definition.Namespace,
+			definition.DefinitionPath(),
+			definition.FromFiles,
+		)
 		if err != nil {
 			logger.Warnx(
 				"failed to generate executables from files",


### PR DESCRIPTION
# Summary

The ws and definition context wasn't being set on generated executables, resulting in errors when running them. This commit pushed down that information when the generated executables are added to the cache

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):
