### PR TITLE
(feat) toggle library pane splitting

### DIFF
--- a/config/executable_md.go
+++ b/config/executable_md.go
@@ -143,7 +143,7 @@ func requestExecMarkdown(r *RequestExecutableType) string {
 		}
 	}
 	if r.TransformResponse != "" {
-		mkdwn += fmt.Sprintf("**Transformation Expression:** ```\n%s\n```\n", r.TransformResponse)
+		mkdwn += fmt.Sprintf("**Transformation Expression:\n** ```\n%s\n```\n", r.TransformResponse)
 	}
 
 	mkdwn += execEnvTable(&r.ExecutableEnvironment)

--- a/config/workspace_config.go
+++ b/config/workspace_config.go
@@ -131,6 +131,15 @@ func (l WorkspaceConfigList) JSON() (string, error) {
 	return string(jsonBytes), nil
 }
 
+func (l WorkspaceConfigList) FindByName(name string) *WorkspaceConfig {
+	for _, ws := range l {
+		if ws.AssignedName() == name {
+			return &ws
+		}
+	}
+	return nil
+}
+
 func (l WorkspaceConfigList) Items() []*types.CollectionItem {
 	items := make([]*types.CollectionItem, 0)
 	for _, ws := range l {

--- a/examples/render.flow
+++ b/examples/render.flow
@@ -1,5 +1,5 @@
 visibility: private
-namespace: example
+namespace: examples
 executables:
   - verb: show
     name: markdown

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/gen2brain/beeep v0.0.0-20240112042604-c7bb2cd88fea
 	github.com/itchyny/gojq v0.12.15
 	github.com/jahvon/open-golang v0.0.0-20240522004812-68511c3bc9ef
-	github.com/jahvon/tuikit v0.0.13
+	github.com/jahvon/tuikit v0.0.14
 	github.com/mattn/go-runewidth v0.0.15
 	github.com/onsi/ginkgo/v2 v2.19.0
 	github.com/onsi/gomega v1.33.1

--- a/go.sum
+++ b/go.sum
@@ -68,8 +68,8 @@ github.com/jahvon/glamour v0.7.1-patch1 h1:v3btiQx2OB0ETStjkXciUjwZBO9fXfSv5flZl
 github.com/jahvon/glamour v0.7.1-patch1/go.mod h1:jUMh5MeihljJPQbJ/wf4ldw2+yBP59+ctV36jASy7ps=
 github.com/jahvon/open-golang v0.0.0-20240522004812-68511c3bc9ef h1:4PS/MNVT6Rsv15x5Rtwaw971e6kFvNUAf9nvUsZ5hcc=
 github.com/jahvon/open-golang v0.0.0-20240522004812-68511c3bc9ef/go.mod h1:dUmuT5CN6osIeLSRtTPJOf0Yz+qAbcyU6omnCzI+ZfQ=
-github.com/jahvon/tuikit v0.0.13 h1:/L9P7PGD/LiUAWFI525ShpAUeHeY7IrvNJFcD9dZ93c=
-github.com/jahvon/tuikit v0.0.13/go.mod h1:6T4MFGAy4aSlDLV5Ka1FUd+TOt/fCXBrsibRpM1I3mI=
+github.com/jahvon/tuikit v0.0.14 h1:JP9EiCxGV0DOzFQdH4F5X/nAO6TU4hjYi5I3xvmeIgM=
+github.com/jahvon/tuikit v0.0.14/go.mod h1:6T4MFGAy4aSlDLV5Ka1FUd+TOt/fCXBrsibRpM1I3mI=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=

--- a/internal/io/library/init.go
+++ b/internal/io/library/init.go
@@ -14,9 +14,6 @@ import (
 
 func (l *Library) Init() tea.Cmd {
 	cmds := make([]tea.Cmd, 0)
-	if l.loadingScreen != nil {
-		cmds = append(cmds, l.loadingScreen.Init())
-	}
 	cmds = append(
 		cmds,
 		tea.SetWindowTitle("flow library"),
@@ -30,6 +27,16 @@ func (l *Library) Init() tea.Cmd {
 		l.paneOneViewport.Init(),
 		l.paneTwoViewport.Init(),
 	)
+
+	l.termWidth = l.ctx.InteractiveContainer.Width()
+	l.termHeight = l.ctx.InteractiveContainer.FullHeight()
+	p0, p1, p2 := calculateViewportWidths(l.termWidth - widthPadding)
+	l.paneZeroViewport.Width = p0
+	l.paneOneViewport.Width = p1
+	l.paneTwoViewport.Width = p2
+	l.paneZeroViewport.Height = l.termHeight - heightPadding
+	l.paneOneViewport.Height = l.termHeight - heightPadding
+	l.paneTwoViewport.Height = l.termHeight - heightPadding
 
 	go func() {
 		l.setVisibleWorkspaces()

--- a/internal/io/library/init.go
+++ b/internal/io/library/init.go
@@ -28,16 +28,7 @@ func (l *Library) Init() tea.Cmd {
 		l.paneTwoViewport.Init(),
 	)
 
-	l.termWidth = l.ctx.InteractiveContainer.Width()
-	l.termHeight = l.ctx.InteractiveContainer.FullHeight()
-	p0, p1, p2 := calculateViewportWidths(l.termWidth - widthPadding)
-	l.paneZeroViewport.Width = p0
-	l.paneOneViewport.Width = p1
-	l.paneTwoViewport.Width = p2
-	l.paneZeroViewport.Height = l.termHeight - heightPadding
-	l.paneOneViewport.Height = l.termHeight - heightPadding
-	l.paneTwoViewport.Height = l.termHeight - heightPadding
-
+	l.setSize()
 	go func() {
 		l.setVisibleWorkspaces()
 		l.setVisibleNamespaces()

--- a/internal/io/library/library.go
+++ b/internal/io/library/library.go
@@ -16,10 +16,10 @@ const (
 )
 
 type Library struct {
-	ctx                      *context.Context
-	termWidth, termHeight    int
-	noticeText               string
-	showHelp, showNamespaces bool
+	ctx                                 *context.Context
+	termWidth, termHeight               int
+	noticeText                          string
+	showHelp, showNamespaces, splitView bool
 
 	visibleWorkspaces  []string
 	visibleNamespaces  []string
@@ -31,6 +31,7 @@ type Library struct {
 	selectedWsConfig   *config.WorkspaceConfig
 
 	currentPane, currentWorkspace, currentNamespace, currentExecutable uint
+	currentFormat, currentHelpPage                                     uint
 	paneZeroViewport, paneOneViewport, paneTwoViewport                 viewport.Model
 
 	cmdRunFunc func(string) error
@@ -88,3 +89,5 @@ func ctxVal(ws, ns string) string {
 	}
 	return fmt.Sprintf("%s/%s", ws, ns)
 }
+
+var formatOrder = []string{"markdown", "yaml", "json"}

--- a/internal/io/library/library.go
+++ b/internal/io/library/library.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/charmbracelet/bubbles/viewport"
-	tea "github.com/charmbracelet/bubbletea"
 	"github.com/jahvon/tuikit/components"
 	"github.com/jahvon/tuikit/styles"
 
@@ -33,7 +32,6 @@ type Library struct {
 
 	currentPane, currentWorkspace, currentNamespace, currentExecutable uint
 	paneZeroViewport, paneOneViewport, paneTwoViewport                 viewport.Model
-	loadingScreen                                                      tea.Model
 
 	cmdRunFunc func(string) error
 }
@@ -56,14 +54,11 @@ func NewLibrary(
 	p1 := viewport.New(0, 0)
 	p2 := viewport.New(0, 0)
 	p3 := viewport.New(0, 0)
-	loadingModel := components.NewLoadingView("Loading...", theme)
-
 	return &Library{
 		ctx:              ctx,
 		allWorkspaces:    workspaces,
 		allExecutables:   execs,
 		filter:           filter,
-		loadingScreen:    loadingModel,
 		paneZeroViewport: p1,
 		paneOneViewport:  p2,
 		paneTwoViewport:  p3,

--- a/internal/io/library/library.go
+++ b/internal/io/library/library.go
@@ -28,7 +28,6 @@ type Library struct {
 	allExecutables     config.ExecutableList
 	filter             Filter
 	theme              styles.Theme
-	selectedWsConfig   *config.WorkspaceConfig
 
 	currentPane, currentWorkspace, currentNamespace, currentExecutable uint
 	currentFormat, currentHelpPage                                     uint
@@ -89,5 +88,3 @@ func ctxVal(ws, ns string) string {
 	}
 	return fmt.Sprintf("%s/%s", ws, ns)
 }
-
-var formatOrder = []string{"markdown", "yaml", "json"}

--- a/internal/io/library/styles.go
+++ b/internal/io/library/styles.go
@@ -43,9 +43,9 @@ func renderPaneTitle(s string, count int, active bool, theme styles.Theme) strin
 	return style.Render(title) + "\n\n"
 }
 
-func paneStyle(pos int, theme styles.Theme) lipgloss.Style {
+func paneStyle(pos int, theme styles.Theme, splitView bool) lipgloss.Style {
 	style := lipgloss.NewStyle().Padding(0, 1)
-	if pos == 2 {
+	if pos == 2 && splitView {
 		style = style.BorderStyle(lipgloss.OuterHalfBlockBorder()).
 			BorderForeground(theme.BorderColor).BorderLeft(true)
 	}
@@ -53,11 +53,18 @@ func paneStyle(pos int, theme styles.Theme) lipgloss.Style {
 	return style
 }
 
-func calculateViewportWidths(termWidth int) (int, int, int) {
-	paneOne := math.Floor(float64(termWidth) * 0.20)
-	paneTwo := math.Floor(float64(termWidth) * 0.20)
-	paneThree := termWidth - int(paneOne) - int(paneTwo)
-	return int(paneOne), int(paneTwo), paneThree
+func calculateViewportWidths(termWidth int, splitView bool) (int, int, int) {
+	if splitView {
+		paneOne := math.Floor(float64(termWidth) * 0.20)
+		paneTwo := math.Floor(float64(termWidth) * 0.30)
+		paneThree := termWidth - int(paneOne) - int(paneTwo)
+		return int(paneOne), int(paneTwo), paneThree
+	} else {
+		paneOne := math.Floor(float64(termWidth) * 0.33)
+		paneTwo := math.Floor(float64(termWidth) * 0.67)
+		paneThree := termWidth
+		return int(paneOne), int(paneTwo), paneThree
+	}
 }
 
 func truncateText(s string, w int) string {

--- a/internal/io/library/update.go
+++ b/internal/io/library/update.go
@@ -17,17 +17,6 @@ import (
 func (l *Library) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	cmds := make([]tea.Cmd, 0)
 	switch msg := msg.(type) {
-	case tea.WindowSizeMsg:
-		l.termWidth = msg.Width
-		l.termHeight = msg.Height
-		p0, p1, p2 := calculateViewportWidths(l.termWidth - widthPadding)
-		l.paneZeroViewport.Width = p0
-		l.paneOneViewport.Width = p1
-		l.paneTwoViewport.Width = p2
-		l.paneZeroViewport.Height = l.termHeight - heightPadding
-		l.paneOneViewport.Height = l.termHeight - heightPadding
-		l.paneTwoViewport.Height = l.termHeight - heightPadding
-		l.loadingScreen = nil
 	case tea.KeyMsg:
 		key := msg.String()
 		switch key {
@@ -52,12 +41,6 @@ func (l *Library) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 	}
 
-	if l.loadingScreen != nil {
-		updatedModel, cmd := l.loadingScreen.Update(msg)
-		l.loadingScreen = updatedModel
-		return l, cmd
-	}
-
 	wsPane, wsCmd := l.updateWsPane(msg)
 	l.paneZeroViewport = wsPane
 	execPane, execCmd := l.updateExecPanes(msg)
@@ -76,7 +59,7 @@ func (l *Library) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (l *Library) updateWsPane(msg tea.Msg) (viewport.Model, tea.Cmd) {
-	if l.loadingScreen != nil || l.currentPane != 0 {
+	if l.currentPane != 0 {
 		return l.paneZeroViewport, nil
 	}
 
@@ -189,7 +172,7 @@ func (l *Library) updateWsPane(msg tea.Msg) (viewport.Model, tea.Cmd) {
 }
 
 func (l *Library) updateExecPanes(msg tea.Msg) (viewport.Model, tea.Cmd) {
-	if l.loadingScreen != nil || (l.currentPane != 1 && l.currentPane != 2) {
+	if l.currentPane != 1 && l.currentPane != 2 {
 		return l.paneOneViewport, nil
 	}
 

--- a/internal/io/library/update.go
+++ b/internal/io/library/update.go
@@ -17,6 +17,8 @@ import (
 func (l *Library) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	cmds := make([]tea.Cmd, 0)
 	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		l.setSize()
 	case tea.KeyMsg:
 		key := msg.String()
 		switch key {

--- a/internal/io/library/update.go
+++ b/internal/io/library/update.go
@@ -50,6 +50,7 @@ func (l *Library) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				l.currentHelpPage = 0
 			}
 		}
+		l.noticeText = ""
 	}
 
 	wsPane, wsCmd := l.updateWsPane(msg)
@@ -81,7 +82,7 @@ func (l *Library) updateWsPane(msg tea.Msg) (viewport.Model, tea.Cmd) {
 	}
 
 	curWs := l.visibleWorkspaces[l.currentWorkspace]
-	curWsCfg := l.selectedWsConfig
+	curWsCfg := l.allWorkspaces.FindByName(curWs)
 	wsCanMoveUp := numWs > 1 && l.currentWorkspace >= 1 && l.currentWorkspace < uint(numWs)
 	wsCanMoveDown := numWs > 1 && l.currentWorkspace < uint(numWs-1)
 

--- a/internal/io/library/update.go
+++ b/internal/io/library/update.go
@@ -33,13 +33,22 @@ func (l *Library) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				l.currentExecutable = 0
 				l.paneOneViewport.GotoTop()
 			}
-		case tea.KeyRight.String():
+		case tea.KeyRight.String(), tea.KeyEnter.String():
 			if l.currentPane == 2 {
 				break
 			}
 			l.currentPane++
+		case tea.KeyTab.String():
+			l.splitView = !l.splitView
+			l.setSize()
 		case "h":
-			l.showHelp = !l.showHelp
+			switch {
+			case l.showHelp && l.currentHelpPage == 0:
+				l.currentHelpPage = 1
+			default:
+				l.showHelp = !l.showHelp
+				l.currentHelpPage = 0
+			}
 		}
 	}
 
@@ -243,6 +252,12 @@ func (l *Library) updateExecPanes(msg tea.Msg) (viewport.Model, tea.Cmd) {
 					l.ctx.Logger.Fatalx("unable to execute command", "error", err)
 				}
 			}()
+		case "f":
+			if l.currentPane == 1 {
+				break
+			}
+			l.currentFormat = (l.currentFormat + 1) % 3
+			pane.GotoTop()
 		}
 	}
 

--- a/internal/io/library/view.go
+++ b/internal/io/library/view.go
@@ -24,12 +24,11 @@ const (
 	withoutNamespaceLabel = "w/o namespace"
 	allNamespacesLabel    = "all namespaces"
 
-	footerPrefix        = "[ q/ctrl+c: quit] [ h: help ]"
-	helpPrefix          = "[ ↑/↓: navigate pane ] [ ←/→: change pane ]"
-	paneOneHelp         = "[ o: open ] [ e: edit ] [ s:set ] ● [ space: show namespaces ]"
-	paneOneExpandedHelp = "[ o: open ] [ e: edit ] [ s:set ] ● [ space: hide namespaces ]"
-	paneTwoHelp         = "[ r: run ] [ e: edit ] [ c: copy ref ]  ● [ f: change format ]"
-	paneThreeHelp       = "[ r: run ] [ e: edit ] [ c: copy ref ]  ● [ f: change format ]"
+	containerHelp        = "[ tab: split view ] [ ↑/↓: navigate pane ] [ ←/→: change pane ]"
+	paneZeroHelp         = "[ o: open ] [ e: edit ] [ s:set ] ● [ space: show namespaces ]"
+	paneZeroExpandedHelp = "[ o: open ] [ e: edit ] [ s:set ] ● [ space: hide namespaces ]"
+	paneOneHelp          = "[ r: run ] [ e: edit ] [ c: copy ref ]"
+	paneTwoHelp          = "[ r: run ] [ e: edit ] [ c: copy ref ]  ● [ f: change format ]"
 )
 
 var (
@@ -39,22 +38,37 @@ var (
 )
 
 func (l *Library) View() string {
-	l.paneZeroViewport.Style = paneStyle(0, l.theme)
+	l.paneZeroViewport.Style = paneStyle(0, l.theme, l.splitView)
 	l.paneZeroViewport.SetContent(l.paneZeroContent())
 
-	l.paneOneViewport.Style = paneStyle(1, l.theme)
+	l.paneOneViewport.Style = paneStyle(1, l.theme, l.splitView)
 	l.paneOneViewport.SetContent(l.paneOneContent())
 
-	l.paneTwoViewport.Style = paneStyle(2, l.theme)
+	l.paneTwoViewport.Style = paneStyle(2, l.theme, l.splitView)
 	l.paneTwoViewport.SetContent(l.paneTwoContent())
-	v := ctxVal(l.ctx.UserConfig.CurrentWorkspace, l.ctx.UserConfig.CurrentNamespace)
+	v := ctxVal(l.ctx.CurrentWorkspace.AssignedName(), l.ctx.UserConfig.CurrentNamespace)
 	header := l.theme.RenderHeader(appName, "ctx", v, l.termWidth)
-	panes := lipgloss.JoinHorizontal(
-		lipgloss.Top,
-		l.paneZeroViewport.View(),
-		l.paneOneViewport.View(),
-		l.paneTwoViewport.View(),
-	)
+	var panes string
+	if l.splitView {
+		panes = lipgloss.JoinHorizontal(
+			lipgloss.Top,
+			l.paneZeroViewport.View(),
+			l.paneOneViewport.View(),
+			l.paneTwoViewport.View(),
+		)
+	} else {
+		switch l.currentPane {
+		case 0, 1:
+			panes = lipgloss.JoinHorizontal(
+				lipgloss.Top,
+				l.paneZeroViewport.View(),
+				l.paneOneViewport.View(),
+			)
+		case 2:
+			panes = l.paneTwoViewport.View()
+		}
+	}
+
 	footer := l.footerContent()
 
 	return lipgloss.JoinVertical(lipgloss.Top, header, panes, footer)
@@ -70,7 +84,7 @@ func (l *Library) SetNotice(notice string, level styles.NoticeLevel) {
 func (l *Library) setSize() {
 	l.termWidth = l.ctx.InteractiveContainer.Width()
 	l.termHeight = l.ctx.InteractiveContainer.FullHeight()
-	p0, p1, p2 := calculateViewportWidths(l.termWidth - widthPadding)
+	p0, p1, p2 := calculateViewportWidths(l.termWidth-widthPadding, l.splitView)
 	l.paneZeroViewport.Width = p0
 	l.paneOneViewport.Width = p1
 	l.paneTwoViewport.Width = p2
@@ -80,6 +94,10 @@ func (l *Library) setSize() {
 }
 
 func (l *Library) paneZeroContent() string {
+	if !l.splitView && l.currentPane == 2 {
+		return ""
+	}
+
 	var sb strings.Builder
 	workspaces := l.visibleWorkspaces
 	namespaces := l.visibleNamespaces
@@ -91,7 +109,7 @@ func (l *Library) paneZeroContent() string {
 		sb.WriteString(l.theme.RenderError("No workspaces found"))
 		return sb.String()
 	}
-	paneWidth, _, _ := calculateViewportWidths(l.termWidth)
+	paneWidth, _, _ := calculateViewportWidths(l.termWidth, l.splitView)
 
 	for i, ws := range workspaces {
 		prefix := "◌ "
@@ -132,6 +150,10 @@ func (l *Library) paneZeroContent() string {
 }
 
 func (l *Library) paneOneContent() string {
+	if !l.splitView && l.currentPane == 2 {
+		return ""
+	}
+
 	var sb strings.Builder
 	sb.WriteString(renderPaneTitle("Executables", len(l.visibleExecutables), l.currentPane == 1, l.theme))
 	if len(l.visibleExecutables) == 0 {
@@ -139,13 +161,13 @@ func (l *Library) paneOneContent() string {
 		return sb.String()
 	}
 
-	_, paneWidth, _ := calculateViewportWidths(l.termWidth)
+	_, paneWidth, _ := calculateViewportWidths(l.termWidth, l.splitView)
 
 	for i, ex := range l.visibleExecutables {
 		if uint(i) == l.currentExecutable {
-			sb.WriteString(renderSelection("* "+truncateText(ex.Ref().GetID(), paneWidth), l.theme))
+			sb.WriteString(renderSelection("* "+truncateText(ex.Ref().String(), paneWidth), l.theme))
 		} else {
-			sb.WriteString(renderInactive("  "+truncateText(ex.Ref().GetID(), paneWidth), l.theme))
+			sb.WriteString(renderInactive("  "+truncateText(ex.Ref().String(), paneWidth), l.theme))
 		}
 		sb.WriteString("\n")
 	}
@@ -155,9 +177,11 @@ func (l *Library) paneOneContent() string {
 func (l *Library) paneTwoContent() string {
 	if len(l.visibleExecutables) == 0 {
 		return ""
+	} else if !l.splitView && l.currentPane != 2 {
+		return ""
 	}
 
-	_, _, maxWidth := calculateViewportWidths(l.termWidth)
+	_, _, maxWidth := calculateViewportWidths(l.termWidth, l.splitView)
 	paneTwoMaxWidth := math.Floor(float64(maxWidth) * 0.95)
 	mdStyles, err := l.theme.MarkdownStyleJSON()
 	if err != nil {
@@ -174,6 +198,22 @@ func (l *Library) paneTwoContent() string {
 
 	ex := l.visibleExecutables[l.currentExecutable]
 	content := ex.Markdown()
+	switch l.currentFormat {
+	case 0:
+		content = ex.Markdown()
+	case 1:
+		content, err = ex.YAML()
+		if err != nil {
+			return l.theme.RenderError(fmt.Sprintf("unable to render yaml: %s", err.Error()))
+		}
+		content = fmt.Sprintf("```yaml\n%s\n```", content)
+	case 2:
+		content, err = ex.JSON()
+		if err != nil {
+			return l.theme.RenderError(fmt.Sprintf("unable to render json: %s", err.Error()))
+		}
+		content = fmt.Sprintf("```json\n%s\n```", content)
+	}
 	viewStr, err := renderer.Render(content)
 	if err != nil {
 		return l.theme.RenderError(fmt.Sprintf("unable to render markdown: %s", err.Error()))
@@ -184,14 +224,22 @@ func (l *Library) paneTwoContent() string {
 
 func (l *Library) footerContent() string {
 	help := l.showHelp
+	if l.currentHelpPage != 0 {
+		return l.theme.RenderFooter(fmt.Sprintf("2/2 %s ● %s", "[ h: exit help ]", containerHelp), l.termWidth)
+	}
+
+	footerPrefix := "[ q/ctrl+c: quit] [ h: help ]"
+	if help {
+		footerPrefix = "1/2 [ h: show more ]"
+	}
 	switch l.currentPane {
 	case 0:
 		if help && l.showNamespaces {
 			return l.theme.RenderFooter(
-				fmt.Sprintf("%s ● %s ● %s", footerPrefix, helpPrefix, paneOneExpandedHelp), l.termWidth,
+				fmt.Sprintf("%s ● %s", footerPrefix, paneZeroExpandedHelp), l.termWidth,
 			)
 		} else if help {
-			return l.theme.RenderFooter(fmt.Sprintf("%s ● %s ● %s", footerPrefix, helpPrefix, paneOneHelp), l.termWidth)
+			return l.theme.RenderFooter(fmt.Sprintf("%s ● %s", footerPrefix, paneZeroHelp), l.termWidth)
 		} else if l.currentWorkspace < uint(len(l.visibleWorkspaces)) {
 			ws := l.visibleWorkspaces[l.currentWorkspace]
 			if ws == allWorkspacesLabel {
@@ -223,13 +271,13 @@ func (l *Library) footerContent() string {
 		}
 	case 1, 2:
 		if help {
-			helpStr := paneTwoHelp
-			if l.currentPane == 3 {
-				helpStr = paneThreeHelp
+			helpStr := paneOneHelp
+			if l.currentPane == 2 {
+				helpStr = paneTwoHelp
 			}
 
 			return l.theme.RenderFooter(
-				fmt.Sprintf("%s ● %s ● %s", footerPrefix, helpPrefix, helpStr), l.termWidth,
+				fmt.Sprintf("%s ● %s", footerPrefix, helpStr), l.termWidth,
 			)
 		} else if l.currentExecutable < uint(len(l.visibleExecutables)) {
 			exec := l.visibleExecutables[l.currentExecutable]

--- a/internal/io/library/view.go
+++ b/internal/io/library/view.go
@@ -39,10 +39,6 @@ var (
 )
 
 func (l *Library) View() string {
-	if l.loadingScreen != nil {
-		return l.loadingScreen.View()
-	}
-
 	l.paneZeroViewport.Style = paneStyle(0, l.theme)
 	l.paneZeroViewport.SetContent(l.paneZeroContent())
 

--- a/internal/io/library/view.go
+++ b/internal/io/library/view.go
@@ -224,7 +224,7 @@ func (l *Library) paneTwoContent() string {
 
 func (l *Library) footerContent() string {
 	help := l.showHelp
-	if l.currentHelpPage != 0 {
+	if help && l.currentHelpPage != 0 {
 		return l.theme.RenderFooter(fmt.Sprintf("2/2 %s ● %s", "[ h: exit help ]", containerHelp), l.termWidth)
 	}
 
@@ -262,9 +262,12 @@ func (l *Library) footerContent() string {
 				break
 			}
 			var info string
-			if len(wsCfg.Tags) > 0 {
+			switch {
+			case l.noticeText != "":
+				info = l.noticeText
+			case len(wsCfg.Tags) > 0:
 				info = fmt.Sprintf("%s(%s) -> %s", wsCfg.DisplayName, wsCfg.Tags.PreviewString(), path)
-			} else {
+			default:
 				info = fmt.Sprintf("%s -> %s", wsCfg.DisplayName, path)
 			}
 			return l.theme.RenderFooter(fmt.Sprintf("%s ● %s", footerPrefix, info), l.termWidth)
@@ -280,13 +283,20 @@ func (l *Library) footerContent() string {
 				fmt.Sprintf("%s ● %s", footerPrefix, helpStr), l.termWidth,
 			)
 		} else if l.currentExecutable < uint(len(l.visibleExecutables)) {
-			exec := l.visibleExecutables[l.currentExecutable]
-			path, err := relativePathFromWd(exec.DefinitionPath())
-			if err != nil {
-				l.ctx.Logger.Error(err, "unable to get relative path from wd")
-				break
+			var info string
+			switch {
+			case l.noticeText != "":
+				info = l.noticeText
+			default:
+				exec := l.visibleExecutables[l.currentExecutable]
+				path, err := relativePathFromWd(exec.DefinitionPath())
+				if err != nil {
+					l.ctx.Logger.Error(err, "unable to get relative path from wd")
+					break
+				}
+				info = path
 			}
-			return l.theme.RenderFooter(fmt.Sprintf("%s ● %s", footerPrefix, path), l.termWidth)
+			return l.theme.RenderFooter(fmt.Sprintf("%s ● %s", footerPrefix, info), l.termWidth)
 		}
 	}
 	return l.theme.RenderFooter(footerPrefix, l.termWidth)

--- a/internal/io/library/view.go
+++ b/internal/io/library/view.go
@@ -67,6 +67,18 @@ func (l *Library) SetNotice(notice string, level styles.NoticeLevel) {
 	l.noticeText = l.theme.RenderNotice(notice, level)
 }
 
+func (l *Library) setSize() {
+	l.termWidth = l.ctx.InteractiveContainer.Width()
+	l.termHeight = l.ctx.InteractiveContainer.FullHeight()
+	p0, p1, p2 := calculateViewportWidths(l.termWidth - widthPadding)
+	l.paneZeroViewport.Width = p0
+	l.paneOneViewport.Width = p1
+	l.paneTwoViewport.Width = p2
+	l.paneZeroViewport.Height = l.termHeight - heightPadding
+	l.paneOneViewport.Height = l.termHeight - heightPadding
+	l.paneTwoViewport.Height = l.termHeight - heightPadding
+}
+
 func (l *Library) paneZeroContent() string {
 	var sb strings.Builder
 	workspaces := l.visibleWorkspaces


### PR DESCRIPTION
# Summary

Use the `tab` key to switch the library's view layout (3 pane split vs 2/1 pane split). This includes a couple other related fixes which incorporates tuikit frame updates, help menu updates, and format key updates.

## Notable Changes

- By default, the library opens with just the ws and exec list panes. The tab key can toggle showing the exec documentation view alongside then. When not in that mode, enter or the -> arrow can be used to select an exec from a list
- Remove library loading model since tuikit will provide one
- Set library size on init and let tuikit handle resizing more naturally

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):
