### PR TITLE
(fix) Include aliases in -f filtering #139

### DIFF
--- a/types/executable/executable.go
+++ b/types/executable/executable.go
@@ -403,9 +403,15 @@ func (l ExecutableList) FilterBySubstring(str string) ExecutableList {
 	filteredExecs := make(ExecutableList, 0)
 	for _, exec := range l {
 		ref := exec.Ref().String()
-		// TODO: Include aliases in search
 		if strings.Contains(ref, str) || strings.Contains(exec.Description, str) {
 			filteredExecs = append(filteredExecs, exec)
+		} else { // search in aliases
+			for _, alias := range exec.Aliases {
+				if strings.Contains(alias, str) {
+					filteredExecs = append(filteredExecs, exec)
+					break
+				}
+			}
 		}
 	}
 	return filteredExecs

--- a/types/executable/executables_test.go
+++ b/types/executable/executables_test.go
@@ -285,6 +285,14 @@ var _ = Describe("ExecutableList", func() {
 			Expect(filtered).To(HaveLen(1))
 			Expect(filtered[0].Name).To(Equal(exec1.Name))
 		})
+
+		It("should return executables when one of the aliases matches", func() {
+			exec1.Aliases = append(exec1.Aliases, "ijklmn")
+			exec1.Aliases = append(exec1.Aliases, "opqrst")
+			filtered := execs.FilterBySubstring("pqr")
+			Expect(filtered).To(HaveLen(1))
+			Expect(filtered[0].Name).To(Equal(exec1.Name))
+		})
 	})
 
 	Describe("FindByVerbAndID", func() {


### PR DESCRIPTION
# Summary

Filter listed executables by their aliases in addition to their ref and description

## Notable Changes

- Listing executables with ```flow list executables -f STRING``` now additionally searches the aliases values and returns any executables with aliases that contain the filter string

## Change Type

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):
