### PR TITLE
(fix) exec markdown formatting for transformed req

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/itchyny/gojq v0.12.16
 	github.com/jahvon/glamour v0.7.1-patch2
 	github.com/jahvon/open-golang v0.0.0-20240522004812-68511c3bc9ef
-	github.com/jahvon/tuikit v0.0.18
+	github.com/jahvon/tuikit v0.0.19
 	github.com/mattn/go-runewidth v0.0.15
 	github.com/onsi/ginkgo/v2 v2.19.0
 	github.com/onsi/gomega v1.33.1

--- a/go.sum
+++ b/go.sum
@@ -68,8 +68,8 @@ github.com/jahvon/glamour v0.7.1-patch2 h1:4rQfkp38pC+f1MLIFQCtgb6I+VSDVXXUDLGAT
 github.com/jahvon/glamour v0.7.1-patch2/go.mod h1:hpSTnc2dgEvUlzNHUKzl/SrZRiMLkk2AgXBQFLuHbFs=
 github.com/jahvon/open-golang v0.0.0-20240522004812-68511c3bc9ef h1:4PS/MNVT6Rsv15x5Rtwaw971e6kFvNUAf9nvUsZ5hcc=
 github.com/jahvon/open-golang v0.0.0-20240522004812-68511c3bc9ef/go.mod h1:dUmuT5CN6osIeLSRtTPJOf0Yz+qAbcyU6omnCzI+ZfQ=
-github.com/jahvon/tuikit v0.0.18 h1:KSfP3rpMk2/VvQdGY6ETO30DFiGP4w0pBmbpG3/i9hE=
-github.com/jahvon/tuikit v0.0.18/go.mod h1:pIu3edo3wSdhiQuBK/x5vpc4dct6aZ6sAWkXgiyigtQ=
+github.com/jahvon/tuikit v0.0.19 h1:yQ6cOZeoDJ2y58taaFSz6zqeTh2lVpMNxEpP6LcWQzY=
+github.com/jahvon/tuikit v0.0.19/go.mod h1:pIu3edo3wSdhiQuBK/x5vpc4dct6aZ6sAWkXgiyigtQ=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=

--- a/types/executable/executable_md.go
+++ b/types/executable/executable_md.go
@@ -160,7 +160,7 @@ func requestExecMarkdown(e *ExecutableEnvironment, r *RequestExecutableType) str
 		}
 	}
 	if r.TransformResponse != "" {
-		mkdwn += fmt.Sprintf("**Transformation Expression:\n** ```\n%s\n```\n", r.TransformResponse)
+		mkdwn += fmt.Sprintf("**Transformation Expression:**\n ```\n%s\n```\n", r.TransformResponse)
 	}
 
 	mkdwn += execEnvTable(e)


### PR DESCRIPTION
# Summary

Small fix for the markdown formatting of executables when a request exec is being transformed.

Additionally bumps tuikit to fix a small bug with debug logs introduced in the last commit

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):
