### PR TITLE
feat: add library flag for all ns filtering

### DIFF
--- a/cmd/internal/flags/types.go
+++ b/cmd/internal/flags/types.go
@@ -45,6 +45,14 @@ var FilterWorkspaceFlag = &Metadata{
 	Required:  false,
 }
 
+var AllNamespacesFlag = &Metadata{
+	Name:      "all",
+	Shorthand: "a",
+	Usage:     "List from all namespaces.",
+	Default:   false,
+	Required:  false,
+}
+
 var FilterNamespaceFlag = &Metadata{
 	Name:      "namespace",
 	Shorthand: "n",

--- a/cmd/internal/library.go
+++ b/cmd/internal/library.go
@@ -31,6 +31,7 @@ func RegisterLibraryCmd(ctx *context.Context, rootCmd *cobra.Command) {
 	RegisterFlag(ctx, libraryCmd, *flags.FilterVerbFlag)
 	RegisterFlag(ctx, libraryCmd, *flags.FilterTagFlag)
 	RegisterFlag(ctx, libraryCmd, *flags.FilterExecSubstringFlag)
+	RegisterFlag(ctx, libraryCmd, *flags.AllNamespacesFlag)
 	registerGlanceLibraryCmd(ctx, libraryCmd)
 	registerViewLibraryCmd(ctx, libraryCmd)
 	rootCmd.AddCommand(libraryCmd)
@@ -48,7 +49,14 @@ func libraryFunc(ctx *context.Context, cmd *cobra.Command, _ []string) {
 	}
 
 	nsFilter := flags.ValueFor[string](ctx, cmd, *flags.FilterNamespaceFlag, false)
-	if nsFilter == "." {
+	allNs := flags.ValueFor[bool](ctx, cmd, *flags.AllNamespacesFlag, false)
+	switch {
+	case allNs && nsFilter != "":
+		logger.PlainTextWarn("cannot use both --all and --namespace flags, ignoring --namespace")
+		fallthrough
+	case allNs:
+		nsFilter = "*"
+	case nsFilter == ".":
 		nsFilter = ctx.Config.CurrentNamespace
 	}
 
@@ -96,6 +104,7 @@ func registerGlanceLibraryCmd(ctx *context.Context, libraryCmd *cobra.Command) {
 	RegisterFlag(ctx, glanceCmd, *flags.FilterVerbFlag)
 	RegisterFlag(ctx, glanceCmd, *flags.FilterTagFlag)
 	RegisterFlag(ctx, glanceCmd, *flags.FilterExecSubstringFlag)
+	RegisterFlag(ctx, glanceCmd, *flags.AllNamespacesFlag)
 	libraryCmd.AddCommand(glanceCmd)
 }
 
@@ -107,7 +116,14 @@ func glanceLibraryCmd(ctx *context.Context, cmd *cobra.Command, _ []string) {
 	}
 
 	nsFilter := flags.ValueFor[string](ctx, cmd, *flags.FilterNamespaceFlag, false)
-	if nsFilter == "." {
+	allNs := flags.ValueFor[bool](ctx, cmd, *flags.AllNamespacesFlag, false)
+	switch {
+	case allNs && nsFilter != "":
+		logger.PlainTextWarn("cannot use both --all and --namespace flags, ignoring --namespace")
+		fallthrough
+	case allNs:
+		nsFilter = "*"
+	case nsFilter == ".":
 		nsFilter = ctx.Config.CurrentNamespace
 	}
 

--- a/docs/cli/flow_library.md
+++ b/docs/cli/flow_library.md
@@ -9,6 +9,7 @@ flow library [flags]
 ### Options
 
 ```
+  -a, --all                List from all namespaces.
   -f, --filter string      Filter executable by reference substring.
   -h, --help               help for library
   -n, --namespace string   Filter executables by namespace.

--- a/docs/cli/flow_library_glance.md
+++ b/docs/cli/flow_library_glance.md
@@ -9,6 +9,7 @@ flow library glance [flags]
 ### Options
 
 ```
+  -a, --all                List from all namespaces.
   -f, --filter string      Filter executable by reference substring.
   -h, --help               help for glance
   -n, --namespace string   Filter executables by namespace.

--- a/internal/cache/executables_cache.go
+++ b/internal/cache/executables_cache.go
@@ -164,7 +164,7 @@ func (c *ExecutableCacheImpl) GetExecutableByRef(logger io.Logger, ref executabl
 	cfg.Executables = append(cfg.Executables, generated...)
 
 	execs := cfg.Executables
-	exec, err := execs.FindByVerbAndID(ref.GetVerb(), ref.GetID())
+	exec, err := execs.FindByVerbAndID(ref.Verb(), ref.ID())
 	if err != nil {
 		return nil, err
 	} else if exec == nil {

--- a/internal/context/context.go
+++ b/internal/context/context.go
@@ -156,7 +156,7 @@ func (ctx *Context) Finalize() {
 }
 
 func ExpandRef(ctx *Context, ref executable.Ref) executable.Ref {
-	id := ref.GetID()
+	id := ref.ID()
 	ws, ns, name := executable.ParseExecutableID(id)
 	if ws == "" {
 		ws = ctx.CurrentWorkspace.AssignedName()
@@ -164,7 +164,7 @@ func ExpandRef(ctx *Context, ref executable.Ref) executable.Ref {
 	if ns == "" {
 		ns = ctx.Config.CurrentNamespace
 	}
-	return executable.NewRef(executable.NewExecutableID(ws, ns, name), ref.GetVerb())
+	return executable.NewRef(executable.NewExecutableID(ws, ns, name), ref.Verb())
 }
 
 func currentWorkspace(cfg *config.Config) (*workspace.Workspace, error) {

--- a/internal/io/library/init.go
+++ b/internal/io/library/init.go
@@ -29,7 +29,7 @@ func (l *Library) Init() tea.Cmd {
 		l.paneTwoViewport.Init(),
 	)
 
-	if l.ctx.TUIContainer.Width() >= 150 {
+	if l.ctx.TUIContainer.Width() >= 100 {
 		l.splitView = true
 	}
 	l.setSize()
@@ -120,8 +120,8 @@ func (l *Library) setVisibleNamespaces() {
 	filterWs := l.visibleWorkspaces[l.currentWorkspace]
 	nsSet := make(map[string]struct{})
 	for _, ex := range l.allExecutables {
-		ns := ex.Ref().GetNamespace()
-		ws := ex.Ref().GetWorkspace()
+		ns := ex.Ref().Namespace()
+		ws := ex.Ref().Workspace()
 		if filter.Namespace != "*" && filter.Namespace != "" && ns != filter.Namespace {
 			continue
 		} else if filterWs != allWorkspacesLabel && filterWs != "" && ws != filterWs {

--- a/internal/io/library/styles.go
+++ b/internal/io/library/styles.go
@@ -3,10 +3,13 @@ package library
 import (
 	"fmt"
 	"math"
+	"strings"
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/jahvon/tuikit/styles"
 	"github.com/mattn/go-runewidth"
+
+	"github.com/jahvon/flow/types/executable"
 )
 
 func renderSelection(s string, theme styles.Theme) string {
@@ -65,6 +68,17 @@ func calculateViewportWidths(termWidth int, splitView bool) (int, int, int) {
 		paneThree := termWidth
 		return int(paneOne), int(paneTwo), paneThree
 	}
+}
+
+func shortRef(ref executable.Ref, ws, ns string) string {
+	shortID := ref.ID()
+	if ws != "" && ref.Workspace() == ws {
+		shortID = strings.Replace(shortID, ws+"/", "", 1)
+	}
+	if ns != "" && ref.Namespace() == ns {
+		shortID = strings.Replace(shortID, ns+":", "", 1)
+	}
+	return executable.NewRef(shortID, ref.Verb()).String()
 }
 
 func truncateText(s string, w int) string {

--- a/internal/io/library/view.go
+++ b/internal/io/library/view.go
@@ -164,11 +164,16 @@ func (l *Library) paneOneContent() string {
 
 	_, paneWidth, _ := calculateViewportWidths(l.termWidth, l.splitView)
 
+	curWs := l.visibleWorkspaces[l.currentWorkspace]
+	var curNs string
+	if len(l.visibleNamespaces) > 0 {
+		curNs = l.visibleNamespaces[l.currentNamespace]
+	}
 	for i, ex := range l.visibleExecutables {
 		if uint(i) == l.currentExecutable {
-			sb.WriteString(renderSelection("* "+truncateText(ex.Ref().String(), paneWidth), l.theme))
+			sb.WriteString(renderSelection("* "+truncateText(shortRef(ex.Ref(), curWs, curNs), paneWidth), l.theme))
 		} else {
-			sb.WriteString(renderInactive("  "+truncateText(ex.Ref().String(), paneWidth), l.theme))
+			sb.WriteString(renderInactive("  "+truncateText(shortRef(ex.Ref(), curWs, curNs), paneWidth), l.theme))
 		}
 		sb.WriteString("\n")
 	}

--- a/tests/utils/sub_execs.go
+++ b/tests/utils/sub_execs.go
@@ -22,7 +22,7 @@ func findSerialSubExecs(root *executable.Executable, flowFiles executable.FlowFi
 	var subExecs []*executable.Executable
 	for _, ref := range serial.Refs {
 		for _, flowFile := range flowFiles {
-			if e, _ := flowFile.Executables.FindByVerbAndID(ref.GetVerb(), ref.GetID()); e != nil {
+			if e, _ := flowFile.Executables.FindByVerbAndID(ref.Verb(), ref.ID()); e != nil {
 				subExecs = append(subExecs, e)
 				break
 			}
@@ -34,7 +34,7 @@ func findSerialSubExecs(root *executable.Executable, flowFiles executable.FlowFi
 		}
 
 		for _, flowFile := range flowFiles {
-			if e, _ := flowFile.Executables.FindByVerbAndID(refCfg.Ref.GetVerb(), refCfg.Ref.GetID()); e != nil {
+			if e, _ := flowFile.Executables.FindByVerbAndID(refCfg.Ref.Verb(), refCfg.Ref.ID()); e != nil {
 				subExecs = append(subExecs, e)
 				break
 			}
@@ -48,7 +48,7 @@ func findParallelSubExecs(root *executable.Executable, flowFiles executable.Flow
 	var subExecs []*executable.Executable
 	for _, ref := range parallel.Refs {
 		for _, flowFile := range flowFiles {
-			if e, _ := flowFile.Executables.FindByVerbAndID(ref.GetVerb(), ref.GetID()); e != nil {
+			if e, _ := flowFile.Executables.FindByVerbAndID(ref.Verb(), ref.ID()); e != nil {
 				subExecs = append(subExecs, e)
 				break
 			}
@@ -60,7 +60,7 @@ func findParallelSubExecs(root *executable.Executable, flowFiles executable.Flow
 		}
 
 		for _, flowFile := range flowFiles {
-			if e, _ := flowFile.Executables.FindByVerbAndID(refCfg.Ref.GetVerb(), refCfg.Ref.GetID()); e != nil {
+			if e, _ := flowFile.Executables.FindByVerbAndID(refCfg.Ref.Verb(), refCfg.Ref.ID()); e != nil {
 				subExecs = append(subExecs, e)
 				break
 			}

--- a/types/executable/executable.go
+++ b/types/executable/executable.go
@@ -451,7 +451,7 @@ func (l ExecutableList) FilterByWorkspace(ws string) ExecutableList {
 }
 
 func (l ExecutableList) FilterByNamespace(ns string) ExecutableList {
-	if ns == "" || ns == "*" {
+	if ns == "*" {
 		return l
 	}
 

--- a/types/executable/ref.go
+++ b/types/executable/ref.go
@@ -176,12 +176,12 @@ func (r Ref) Validate() error {
 	return nil
 }
 
-func (r Ref) GetVerb() Verb {
+func (r Ref) Verb() Verb {
 	refParts := strings.Split(string(r), " ")
 	return Verb(refParts[0])
 }
 
-func (r Ref) GetID() string {
+func (r Ref) ID() string {
 	refParts := strings.Split(string(r), " ")
 	if len(refParts) != 2 {
 		// TODO: return or log error
@@ -190,24 +190,24 @@ func (r Ref) GetID() string {
 	return refParts[1]
 }
 
-func (r Ref) GetNamespace() string {
-	id := r.GetID()
+func (r Ref) Namespace() string {
+	id := r.ID()
 	_, ns, _ := ParseExecutableID(id)
 	return ns
 }
 
-func (r Ref) GetWorkspace() string {
-	id := r.GetID()
+func (r Ref) Workspace() string {
+	id := r.ID()
 	ws, _, _ := ParseExecutableID(id)
 	return ws
 }
 
 func (r Ref) Equals(other Ref) bool {
-	rVerb := r.GetVerb()
-	oVerb := other.GetVerb()
+	rVerb := r.Verb()
+	oVerb := other.Verb()
 	if !rVerb.Equals(oVerb) {
 		return false
 	}
 
-	return r.GetID() == other.GetID()
+	return r.ID() == other.ID()
 }


### PR DESCRIPTION
# Summary

By default only show executables in the root namespace with options to show all namespaces. Includes improvements for ref displays in the library view.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):
