### PR TITLE
test!: create ws e2e tests with subcommand updates

### DIFF
--- a/cmd/internal/config.go
+++ b/cmd/internal/config.go
@@ -76,44 +76,11 @@ func registerSetConfigCmd(ctx *context.Context, configCmd *cobra.Command) {
 		Aliases: []string{"s", "update"},
 		Short:   "Update flow configuration values.",
 	}
-	registerSetWorkspaceCmd(ctx, setCmd)
 	registerSetNamespaceCmd(ctx, setCmd)
 	registerSetWorkspaceModeCmd(ctx, setCmd)
 	registerSetLogModeCmd(ctx, setCmd)
 	registerSetTUICmd(ctx, setCmd)
 	configCmd.AddCommand(setCmd)
-}
-
-func registerSetWorkspaceCmd(ctx *context.Context, setCmd *cobra.Command) {
-	workspaceCmd := &cobra.Command{
-		Use:     "workspace NAME",
-		Aliases: []string{"ws"},
-		Short:   "Change the current workspace.",
-		Args:    cobra.ExactArgs(1),
-		PreRun:  func(cmd *cobra.Command, args []string) { printContext(ctx, cmd) },
-		Run:     func(cmd *cobra.Command, args []string) { setWorkspaceFunc(ctx, cmd, args) },
-	}
-	RegisterFlag(ctx, workspaceCmd, *flags.FixedWsModeFlag)
-	setCmd.AddCommand(workspaceCmd)
-}
-
-func setWorkspaceFunc(ctx *context.Context, cmd *cobra.Command, args []string) {
-	logger := ctx.Logger
-	workspace := args[0]
-	userConfig := ctx.Config
-	if _, found := userConfig.Workspaces[workspace]; !found {
-		logger.Fatalf("workspace %s not found", workspace)
-	}
-	userConfig.CurrentWorkspace = workspace
-	fixedMode := flags.ValueFor[bool](ctx, cmd, *flags.FixedWsModeFlag, false)
-	if fixedMode {
-		userConfig.WorkspaceMode = config.ConfigWorkspaceModeFixed
-	}
-
-	if err := filesystem.WriteConfig(userConfig); err != nil {
-		logger.FatalErr(err)
-	}
-	logger.PlainTextSuccess("Workspace set to " + workspace)
 }
 
 func registerSetNamespaceCmd(ctx *context.Context, setCmd *cobra.Command) {

--- a/cmd/internal/workspace.go
+++ b/cmd/internal/workspace.go
@@ -20,6 +20,7 @@ import (
 	"github.com/jahvon/flow/internal/io"
 	workspaceIO "github.com/jahvon/flow/internal/io/workspace"
 	"github.com/jahvon/flow/types/common"
+	"github.com/jahvon/flow/types/config"
 	"github.com/jahvon/flow/types/workspace"
 )
 
@@ -29,26 +30,27 @@ func RegisterWorkspaceCmd(ctx *context.Context, rootCmd *cobra.Command) {
 		Aliases: []string{"ws"},
 		Short:   "Manage flow workspaces.",
 	}
-	registerNewWorkspaceCmd(ctx, wsCmd)
+	registerCreateWorkspaceCmd(ctx, wsCmd)
+	registerSetWorkspaceCmd(ctx, wsCmd)
 	registerDeleteWsCmd(ctx, wsCmd)
 	registerListWorkspaceCmd(ctx, wsCmd)
 	registerViewWsCmd(ctx, wsCmd)
 	rootCmd.AddCommand(wsCmd)
 }
 
-func registerNewWorkspaceCmd(ctx *context.Context, wsCmd *cobra.Command) {
-	newCmd := &cobra.Command{
-		Use:     "new NAME PATH",
-		Aliases: []string{"init", "create"},
+func registerCreateWorkspaceCmd(ctx *context.Context, wsCmd *cobra.Command) {
+	createCmd := &cobra.Command{
+		Use:     "create NAME PATH",
+		Aliases: []string{"init"},
 		Short:   "Initialize a new workspace and register it in the user configurations.",
 		Args:    cobra.ExactArgs(2),
-		Run:     func(cmd *cobra.Command, args []string) { newWorkspaceFunc(ctx, cmd, args) },
+		Run:     func(cmd *cobra.Command, args []string) { createWorkspaceFunc(ctx, cmd, args) },
 	}
-	RegisterFlag(ctx, newCmd, *flags.SetAfterCreateFlag)
-	wsCmd.AddCommand(newCmd)
+	RegisterFlag(ctx, createCmd, *flags.SetAfterCreateFlag)
+	wsCmd.AddCommand(createCmd)
 }
 
-func newWorkspaceFunc(ctx *context.Context, cmd *cobra.Command, args []string) {
+func createWorkspaceFunc(ctx *context.Context, cmd *cobra.Command, args []string) {
 	logger := ctx.Logger
 	name := args[0]
 	path := args[1]
@@ -107,6 +109,38 @@ func newWorkspaceFunc(ctx *context.Context, cmd *cobra.Command, args []string) {
 	logger.PlainTextSuccess(fmt.Sprintf("Workspace '%s' created in %s", name, path))
 }
 
+func registerSetWorkspaceCmd(ctx *context.Context, setCmd *cobra.Command) {
+	workspaceCmd := &cobra.Command{
+		Use:     "set NAME",
+		Aliases: []string{"update"},
+		Short:   "Change the current workspace.",
+		Args:    cobra.ExactArgs(1),
+		PreRun:  func(cmd *cobra.Command, args []string) { printContext(ctx, cmd) },
+		Run:     func(cmd *cobra.Command, args []string) { setWorkspaceFunc(ctx, cmd, args) },
+	}
+	RegisterFlag(ctx, workspaceCmd, *flags.FixedWsModeFlag)
+	setCmd.AddCommand(workspaceCmd)
+}
+
+func setWorkspaceFunc(ctx *context.Context, cmd *cobra.Command, args []string) {
+	logger := ctx.Logger
+	workspace := args[0]
+	userConfig := ctx.Config
+	if _, found := userConfig.Workspaces[workspace]; !found {
+		logger.Fatalf("workspace %s not found", workspace)
+	}
+	userConfig.CurrentWorkspace = workspace
+	fixedMode := flags.ValueFor[bool](ctx, cmd, *flags.FixedWsModeFlag, false)
+	if fixedMode {
+		userConfig.WorkspaceMode = config.ConfigWorkspaceModeFixed
+	}
+
+	if err := filesystem.WriteConfig(userConfig); err != nil {
+		logger.FatalErr(err)
+	}
+	logger.PlainTextSuccess("Workspace set to " + workspace)
+}
+
 func registerDeleteWsCmd(ctx *context.Context, wsCmd *cobra.Command) {
 	deleteCmd := &cobra.Command{
 		Use:     "delete NAME",
@@ -161,7 +195,7 @@ func deleteWsFunc(ctx *context.Context, _ *cobra.Command, args []string) {
 		logger.FatalErr(err)
 	}
 
-	logger.Warnf("Workspace '%s' removed", name)
+	logger.Warnf("Workspace '%s' deleted", name)
 
 	if err := cache.UpdateAll(logger); err != nil {
 		logger.FatalErr(errors.Wrap(err, "unable to update cache"))

--- a/docs/cli/flow_config_set.md
+++ b/docs/cli/flow_config_set.md
@@ -22,6 +22,5 @@ Update flow configuration values.
 * [flow config set log-mode](flow_config_set_log-mode.md)	 - Set the default log mode.
 * [flow config set namespace](flow_config_set_namespace.md)	 - Change the current namespace.
 * [flow config set tui](flow_config_set_tui.md)	 - Enable or disable the interactive terminal UI experience.
-* [flow config set workspace](flow_config_set_workspace.md)	 - Change the current workspace.
 * [flow config set workspace-mode](flow_config_set_workspace-mode.md)	 - Switch between fixed and dynamic workspace modes.
 

--- a/docs/cli/flow_workspace.md
+++ b/docs/cli/flow_workspace.md
@@ -19,8 +19,9 @@ Manage flow workspaces.
 ### SEE ALSO
 
 * [flow](flow.md)	 - flow is a command line interface designed to make managing and running development workflows easier.
+* [flow workspace create](flow_workspace_create.md)	 - Initialize a new workspace and register it in the user configurations.
 * [flow workspace delete](flow_workspace_delete.md)	 - Remove an existing workspace from the global configuration's workspaces list.
 * [flow workspace list](flow_workspace_list.md)	 - View a list of registered workspaces.
-* [flow workspace new](flow_workspace_new.md)	 - Initialize a new workspace and register it in the user configurations.
+* [flow workspace set](flow_workspace_set.md)	 - Change the current workspace.
 * [flow workspace view](flow_workspace_view.md)	 - View the documentation for a workspace. If the name is omitted, the current workspace is used.
 

--- a/docs/cli/flow_workspace_create.md
+++ b/docs/cli/flow_workspace_create.md
@@ -1,0 +1,27 @@
+## flow workspace create
+
+Initialize a new workspace and register it in the user configurations.
+
+```
+flow workspace create NAME PATH [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for create
+  -s, --set    Set the newly created workspace as the current workspace
+```
+
+### Options inherited from parent commands
+
+```
+  -x, --non-interactive   Disable displaying flow output via terminal UI rendering. This is only needed if the interactive output is enabled by default in flow's configuration.
+      --sync              Sync flow cache and workspaces
+      --verbosity int     Log verbosity level (-1 to 1)
+```
+
+### SEE ALSO
+
+* [flow workspace](flow_workspace.md)	 - Manage flow workspaces.
+

--- a/docs/cli/flow_workspace_set.md
+++ b/docs/cli/flow_workspace_set.md
@@ -1,16 +1,16 @@
-## flow workspace new
+## flow workspace set
 
-Initialize a new workspace and register it in the user configurations.
+Change the current workspace.
 
 ```
-flow workspace new NAME PATH [flags]
+flow workspace set NAME [flags]
 ```
 
 ### Options
 
 ```
-  -h, --help   help for new
-  -s, --set    Set the newly created workspace as the current workspace
+  -f, --fixed   Set the workspace mode to fixed
+  -h, --help    help for set
 ```
 
 ### Options inherited from parent commands

--- a/docs/development.md
+++ b/docs/development.md
@@ -13,12 +13,12 @@ building the project.
 ## Getting Started
 
 Before developing on this project, you will need to make sure you have the latest `flow` version installed.
-Refer to the [Installation](../README.md#installation) section for more information.
+Refer to the [Installation](installation.md) section for more information.
 
 After cloning the repository, you can start using the below commands after registering the repo workspace:
 
 ```sh
-flow workspace new flow <repo-path>
+flow workspace create flow <repo-path>
 ```
 
 ### Development Executables
@@ -63,10 +63,11 @@ _You should test all tuikit changes with a local flow build before submitting a 
 
 ## Development Tools
 
-The following tools are required for development:
+Required tools for development:
 
 - [mockgen](https://github.com/uber-go/mock) for generating test mocks
 - [golangci-lint](https://golangci-lint.run/) for linting
 
-Additionally, we recommend using the [ginkgo CLI](https://onsi.github.io/ginkgo/#ginkgo-cli-overview) for setting up and running tests.
-
+Other tools used in the project:
+- [goreleaser](https://goreleaser.com/) for releasing the project
+- [ginkgo](https://onsi.github.io/ginkgo/) and [gomega](https://onsi.github.io/gomega/) for testing

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -11,7 +11,7 @@ A workspace can be created anywhere on your system but must be registered in ord
 To create a new workspace, run the following command in the directory where you want the workspace to be created:
 
 ```shell
-flow workspace new my-workspace .
+flow workspace create my-workspace .
 ```
 
 You can replace `my-workspace` with any name you want to give your workspace and `.` with the path to the root directory 

--- a/tests/workspace_cmds_e2e_test.go
+++ b/tests/workspace_cmds_e2e_test.go
@@ -1,0 +1,98 @@
+package tests_test
+
+import (
+	stdCtx "context"
+	"fmt"
+	"os"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jahvon/flow/internal/context"
+	"github.com/jahvon/flow/tests/utils"
+)
+
+var _ = Describe("workspace e2e", Ordered, func() {
+	var (
+		ctx *context.Context
+		run *utils.CommandRunner
+
+		wsName, wsPath, origWsName string
+	)
+
+	BeforeAll(func() {
+		ctx = utils.NewContext(stdCtx.Background(), GinkgoT())
+		run = utils.NewE2ECommandRunner()
+		tmp, err := os.MkdirTemp("", "flow-test-*")
+		Expect(err).NotTo(HaveOccurred())
+		origWsName = ctx.Config.CurrentWorkspace
+		wsName = "test-workspace"
+		wsPath = tmp
+	})
+
+	BeforeEach(func() {
+		utils.ResetTestContext(ctx, GinkgoT())
+	})
+
+	AfterEach(func() {
+		ctx.Finalize()
+	})
+
+	AfterAll(func() {
+		Expect(os.RemoveAll(wsPath)).To(Succeed())
+	})
+
+	When("creating a new workspace (flow workspace create)", func() {
+		It("creates successfully", func() {
+			stdOut := ctx.StdOut()
+			Expect(run.Run(ctx, "workspace", "create", wsName, wsPath)).To(Succeed())
+			out, err := readFileContent(stdOut)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(out).To(ContainSubstring(fmt.Sprintf("Workspace '%s' created", wsName)))
+		})
+	})
+
+	When("setting a workspace (flow workspace set)", func() {
+		It("sets successfully", func() {
+			Expect(run.Run(ctx, "workspace", "set", wsName)).To(Succeed())
+			out, err := readFileContent(ctx.StdOut())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(out).To(ContainSubstring(fmt.Sprintf("Workspace set to %s", wsName)))
+		})
+	})
+
+	When("getting a workspace (flow workspace view)", func() {
+		It("should returns the workspace", func() {
+			stdOut := ctx.StdOut()
+			Expect(run.Run(ctx, "workspace", "view", wsName)).To(Succeed())
+			out, err := readFileContent(stdOut)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(out).To(ContainSubstring(wsName))
+		})
+	})
+
+	When("listing workspaces (flow workspace list)", func() {
+		It("should return the list of workspaces", func() {
+			stdOut := ctx.StdOut()
+			Expect(run.Run(ctx, "workspace", "list")).To(Succeed())
+			out, err := readFileContent(stdOut)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(out).To(ContainSubstring(wsName))
+		})
+	})
+
+	When("deleting a workspace (flow workspace delete)", func() {
+		It("should remove the workspace from the user config", func() {
+			reader, writer, err := os.Pipe()
+			Expect(err).NotTo(HaveOccurred())
+			_, err = writer.Write([]byte("yes\n"))
+			Expect(err).ToNot(HaveOccurred())
+
+			ctx.SetIO(reader, ctx.StdOut())
+			Expect(run.Run(ctx, "workspace", "delete", origWsName)).To(Succeed())
+			out, err := readFileContent(ctx.StdOut())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(out).To(ContainSubstring(fmt.Sprintf("Workspace '%s' deleted", origWsName)))
+		})
+	})
+})


### PR DESCRIPTION
Additional test coverage that comes with a couple subcommand updates:

- `flow workspace new` -> `flow workspace create` 
- `flow config set workspace` -> `flow workspace set`