### PR TITLE
fix: return error on invalid ref config

### DIFF
--- a/internal/runner/parallel/parallel.go
+++ b/internal/runner/parallel/parallel.go
@@ -70,6 +70,8 @@ func handleExec(
 			}
 		case refConfig.Cmd != "":
 			exec = execUtils.ExecutableForCmd(parent, refConfig.Cmd, i)
+		default:
+			return errors.New("parallel executable must have a ref or cmd")
 		}
 
 		execPromptedEnv := make(map[string]string)

--- a/internal/runner/serial/serial.go
+++ b/internal/runner/serial/serial.go
@@ -63,6 +63,8 @@ func handleExec(
 			}
 		case refConfig.Cmd != "":
 			exec = execUtils.ExecutableForCmd(parent, refConfig.Cmd, i)
+		default:
+			return errors.New("serial executable must have a ref or cmd")
 		}
 		ctx.Logger.Debugf("executing %s (%d/%d)", exec.Ref(), i+1, len(serialSpec.Execs))
 


### PR DESCRIPTION
This "fixes" a panic that happens if the cmd or ref isn't defined for a serial or parallel exec
