### PR TITLE
refactor: include all ws and exec data in json

### DIFF
--- a/types/executable/executable.go
+++ b/types/executable/executable.go
@@ -67,11 +67,11 @@ type enrichedExecutableList struct {
 type enrichedExecutable struct {
 	*Executable
 
-	ID              string `json:"id"        yaml:"id"`
-	Ref             string `json:"ref"       yaml:"ref"`
-	Namespace       string `json:"namespace" yaml:"namespace"`
-	Workspace       string `json:"workspace" yaml:"workspace"`
-	Flowfile        string `json:"flowfile"  yaml:"flowfile"`
+	ID              string `json:"id"              yaml:"id"`
+	Ref             string `json:"ref"             yaml:"ref"`
+	Namespace       string `json:"namespace"       yaml:"namespace"`
+	Workspace       string `json:"workspace"       yaml:"workspace"`
+	Flowfile        string `json:"flowfile"        yaml:"flowfile"`
 	FullDescription string `json:"fullDescription" yaml:"fullDescription"`
 }
 
@@ -544,7 +544,6 @@ func (e *Executable) MarshalJSON() ([]byte, error) {
 		aux.Timeout = e.Timeout.String()
 	}
 	return json.Marshal(aux)
-
 }
 
 func (e *Executable) UnmarshalJSON(data []byte) error {

--- a/types/executable/executable.go
+++ b/types/executable/executable.go
@@ -63,9 +63,16 @@ func (e *ExecExecutableType) GetLogFields() map[string]interface{} {
 type enrichedExecutableList struct {
 	Executables []*enrichedExecutable `json:"executables" yaml:"executables"`
 }
+
 type enrichedExecutable struct {
-	ID   string      `json:"id"   yaml:"id"`
-	Spec *Executable `json:"spec" yaml:"spec"`
+	*Executable
+
+	ID              string `json:"id"        yaml:"id"`
+	Ref             string `json:"ref"       yaml:"ref"`
+	Namespace       string `json:"namespace" yaml:"namespace"`
+	Workspace       string `json:"workspace" yaml:"workspace"`
+	Flowfile        string `json:"flowfile"  yaml:"flowfile"`
+	FullDescription string `json:"fullDescription" yaml:"fullDescription"`
 }
 
 func (e *Executable) SetContext(workspaceName, workspacePath, namespace, flowFilePath string) {
@@ -93,12 +100,20 @@ func (e *Executable) SetInheritedFields(flowFile *FlowFile) {
 	e.inheritedDescription = strings.Join([]string{flowFile.Description, descFromFIle}, "\n")
 }
 
-func (e *Executable) YAML() (string, error) {
-	enriched := &enrichedExecutable{
-		ID:   e.ID(),
-		Spec: e,
+func (e *Executable) enriched() *enrichedExecutable {
+	return &enrichedExecutable{
+		Executable:      e,
+		ID:              e.ID(),
+		Ref:             e.Ref().String(),
+		Namespace:       e.Namespace(),
+		Workspace:       e.Workspace(),
+		Flowfile:        e.FlowFilePath(),
+		FullDescription: execDescriptionMarkdown(e),
 	}
-	yamlBytes, err := yaml.Marshal(enriched)
+}
+
+func (e *Executable) YAML() (string, error) {
+	yamlBytes, err := yaml.Marshal(e.enriched())
 	if err != nil {
 		return "", fmt.Errorf("failed to marshal executable - %w", err)
 	}
@@ -106,11 +121,7 @@ func (e *Executable) YAML() (string, error) {
 }
 
 func (e *Executable) JSON() (string, error) {
-	enriched := &enrichedExecutable{
-		ID:   e.ID(),
-		Spec: e,
-	}
-	jsonBytes, err := json.MarshalIndent(enriched, "", "  ")
+	jsonBytes, err := json.MarshalIndent(e.enriched(), "", "  ")
 	if err != nil {
 		return "", fmt.Errorf("failed to marshal executable - %w", err)
 	}
@@ -316,10 +327,7 @@ func (e *Executable) IsExecutableFromWorkspace(workspaceFilter string) bool {
 func (l ExecutableList) YAML() (string, error) {
 	enriched := &enrichedExecutableList{}
 	for _, exec := range l {
-		enriched.Executables = append(enriched.Executables, &enrichedExecutable{
-			ID:   exec.ID(),
-			Spec: exec,
-		})
+		enriched.Executables = append(enriched.Executables, exec.enriched())
 	}
 	yamlBytes, err := yaml.Marshal(enriched)
 	if err != nil {
@@ -331,10 +339,7 @@ func (l ExecutableList) YAML() (string, error) {
 func (l ExecutableList) JSON() (string, error) {
 	enriched := &enrichedExecutableList{}
 	for _, exec := range l {
-		enriched.Executables = append(enriched.Executables, &enrichedExecutable{
-			ID:   exec.ID(),
-			Spec: exec,
-		})
+		enriched.Executables = append(enriched.Executables, exec.enriched())
 	}
 	jsonBytes, err := json.MarshalIndent(enriched, "", "  ")
 	if err != nil {
@@ -525,4 +530,90 @@ func NewExecutableID(workspace, namespace, name string) string {
 		// for now, exclude the workspace from the string (until we can indicate that it's root / not named in the tui)
 		return ""
 	}
+}
+
+// MarshalJSON implements custom JSON marshaling for Executable
+func (e *Executable) MarshalJSON() ([]byte, error) {
+	output := make(map[string]interface{})
+
+	type BaseExecutable Executable
+	baseData, err := json.Marshal((*BaseExecutable)(e))
+	if err != nil {
+		return nil, err
+	}
+
+	if err := json.Unmarshal(baseData, &output); err != nil {
+		return nil, err
+	}
+
+	// Add the enriched fields for the YAML and JSON functions
+	output["id"] = e.ID()
+	output["ref"] = e.Ref().String()
+	output["namespace"] = e.Namespace()
+	output["workspace"] = e.Workspace()
+	output["flowfile"] = e.FlowFilePath()
+	output["fullDescription"] = execDescriptionMarkdown(e)
+
+	// Convert timeout to string
+	output["timeout"] = e.Timeout.String()
+
+	// Marshal the complete map to JSON
+	return json.Marshal(output)
+}
+
+// UnmarshalJSON implements custom JSON unmarshaling for Executable
+func (e *Executable) UnmarshalJSON(data []byte) error {
+	type Alias Executable
+	aux := &struct {
+		*Alias
+		Timeout string `json:"timeout,omitempty"`
+	}{
+		Alias: (*Alias)(e),
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	if aux.Timeout != "" {
+		duration, err := time.ParseDuration(aux.Timeout)
+		if err != nil {
+			return err
+		}
+		e.Timeout = duration
+	}
+	return nil
+}
+
+func (r *RequestExecutableType) MarshalJSON() ([]byte, error) {
+	type Alias RequestExecutableType
+	aux := &struct {
+		*Alias
+		Timeout string `json:"timeout,omitempty"`
+	}{
+		Alias: (*Alias)(r),
+	}
+	if r.Timeout != 0 {
+		aux.Timeout = r.Timeout.String()
+	}
+	return json.Marshal(aux)
+}
+
+func (r *RequestExecutableType) UnmarshalJSON(data []byte) error {
+	type Alias RequestExecutableType
+	aux := &struct {
+		*Alias
+		Timeout string `json:"timeout,omitempty"`
+	}{
+		Alias: (*Alias)(r),
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	if aux.Timeout != "" {
+		duration, err := time.ParseDuration(aux.Timeout)
+		if err != nil {
+			return err
+		}
+		r.Timeout = duration
+	}
+	return nil
 }

--- a/types/executable/executable_md.go
+++ b/types/executable/executable_md.go
@@ -10,7 +10,7 @@ import (
 func execMarkdown(e *Executable) string {
 	var mkdwn string
 	mkdwn += fmt.Sprintf("# [Executable] %s\n", e.Ref())
-	mkdwn += execDescriptionMarkdown(e)
+	mkdwn += execDescriptionMarkdown(e, true)
 	if e.Visibility != nil {
 		mkdwn += fmt.Sprintf("**Visibility:** %s\n", *e.Visibility)
 	}
@@ -38,12 +38,16 @@ func execMarkdown(e *Executable) string {
 	return mkdwn
 }
 
-func execDescriptionMarkdown(e *Executable) string {
+func execDescriptionMarkdown(e *Executable, withPrefix bool) string {
 	if e.Description == "" && e.inheritedDescription == "" {
 		return ""
 	}
 	var mkdwn string
-	const prefix = "│ "
+
+	prefix := ""
+	if withPrefix {
+		prefix = "│ "
+	}
 	if d := strings.TrimSpace(e.Description); d != "" {
 		mkdwn += prefix + "\n"
 		mkdwn += addPrefx(d, prefix)

--- a/types/workspace/workspace.go
+++ b/types/workspace/workspace.go
@@ -3,6 +3,7 @@ package workspace
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/jahvon/tuikit/types"
 	"gopkg.in/yaml.v3"
@@ -31,7 +32,7 @@ func (w *Workspace) enriched() *enrichedWorkspace {
 		Workspace:       w,
 		Name:            w.AssignedName(),
 		Path:            w.Location(),
-		FullDescription: workspaceDescription(w),
+		FullDescription: strings.TrimSpace(workspaceDescription(w, false)),
 	}
 }
 

--- a/types/workspace/workspace.go
+++ b/types/workspace/workspace.go
@@ -22,8 +22,8 @@ type enrichedWorkspaceList struct {
 
 type enrichedWorkspace struct {
 	*Workspace
-	Name            string `json:"name" yaml:"name"`
-	Path            string `json:"path" yaml:"path"`
+	Name            string `json:"name"            yaml:"name"`
+	Path            string `json:"path"            yaml:"path"`
 	FullDescription string `json:"fullDescription" yaml:"fullDescription"`
 }
 

--- a/types/workspace/workspace_md.go
+++ b/types/workspace/workspace_md.go
@@ -52,7 +52,8 @@ func workspaceDescription(w *Workspace) string {
 		mkdwn += descSpacer
 	}
 	if w.DescriptionFile != "" {
-		mdBytes, err := os.ReadFile(filepath.Clean(w.DescriptionFile))
+		wsFile := filepath.Join(w.Location(), w.DescriptionFile)
+		mdBytes, err := os.ReadFile(filepath.Clean(wsFile))
 		if err != nil {
 			mkdwn += fmt.Sprintf("> **error rendering description file**: %s\n", err)
 		} else {


### PR DESCRIPTION
### Refactoring and Serialization Enhancements:

* Introduced `enrichedExecutable` and `enrichedWorkspace` structs to encapsulate additional metadata (e.g., `FullDescription`, `Namespace`, `Path`) for better YAML/JSON serialization. 

* Added custom `MarshalJSON` and `UnmarshalJSON` methods for `Executable` and `RequestExecutableType` to handle timeout serialization/deserialization as strings, ensuring compatibility with JSON formats (`types/executable/executable.go`).
