### PR TITLE
refactor: remove the default timeout for executables

### DIFF
--- a/docs/schemas/flowfile_schema.json
+++ b/docs/schemas/flowfile_schema.json
@@ -76,8 +76,7 @@
         },
         "timeout": {
           "description": "The maximum amount of time the executable is allowed to run before being terminated.\nThe timeout is specified in Go duration format (e.g. 30s, 5m, 1h).\n",
-          "type": "string",
-          "default": "30m0s"
+          "type": "string"
         },
         "verb": {
           "$ref": "#/definitions/ExecutableVerb",

--- a/docs/types/flowfile.md
+++ b/docs/types/flowfile.md
@@ -90,7 +90,7 @@ Executables are the building blocks of workflows and are used to define the acti
 | `request` |  | [ExecutableRequestExecutableType](#ExecutableRequestExecutableType) | <no value> |  |
 | `serial` |  | [ExecutableSerialExecutableType](#ExecutableSerialExecutableType) | <no value> |  |
 | `tags` |  | [CommonTags](#CommonTags) | [] |  |
-| `timeout` | The maximum amount of time the executable is allowed to run before being terminated. The timeout is specified in Go duration format (e.g. 30s, 5m, 1h).  | `string` | 30m0s |  |
+| `timeout` | The maximum amount of time the executable is allowed to run before being terminated. The timeout is specified in Go duration format (e.g. 30s, 5m, 1h).  | `string` | <no value> |  |
 | `verb` |  | [ExecutableVerb](#ExecutableVerb) | exec | ✘ |
 | `visibility` |  | [CommonVisibility](#CommonVisibility) | <no value> |  |
 

--- a/internal/cache/executable_generator.go
+++ b/internal/cache/executable_generator.go
@@ -58,7 +58,7 @@ func executablesFromFile(logger io.Logger, fileBase, filePath string) (*executab
 			if err != nil {
 				return nil, errors.Wrapf(err, "unable to parse timeout duration %s", value)
 			}
-			exec.Timeout = dur
+			exec.Timeout = &dur
 		case fileparser.VerbConfigurationKey:
 			exec.Verb = executable.Verb(value)
 		case fileparser.NameConfigurationKey:

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -43,7 +43,7 @@ func Exec(
 		return fmt.Errorf("compatible runner not found for executable %s", executable.ID())
 	}
 
-	if executable.Timeout == 0 {
+	if executable.Timeout == nil {
 		return assignedRunner.Exec(ctx, executable, eng, inputEnv)
 	}
 
@@ -55,8 +55,8 @@ func Exec(
 	select {
 	case err := <-done:
 		return err
-	case <-time.After(executable.Timeout):
-		return fmt.Errorf("timeout after %v", executable.Timeout)
+	case <-time.After(*executable.Timeout):
+		return fmt.Errorf("timeout after %v", *executable.Timeout)
 	}
 }
 

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -69,9 +69,10 @@ var _ = Describe("Runner", func() {
 
 		It("should return error when execution times out", func() {
 			ctx := &context.Context{}
+			timeout := 250 * time.Millisecond
 			exec := &executable.Executable{
 				Name:    "test-exec",
-				Timeout: 250 * time.Millisecond,
+				Timeout: &timeout,
 			}
 			promptedEnv := make(map[string]string)
 

--- a/tools/builder/exec.go
+++ b/tools/builder/exec.go
@@ -91,7 +91,7 @@ func ExecWithTimeout(opts ...Option) *executable.Executable {
 		Name:        name,
 		Visibility:  privateExecVisibility(),
 		Description: docstring,
-		Timeout:     timeout,
+		Timeout:     &timeout,
 		Exec: &executable.ExecExecutableType{
 			Cmd: fmt.Sprintf("sleep %d", int(timeout.Seconds()+10)),
 		},

--- a/types/executable/executable.gen.go
+++ b/types/executable/executable.gen.go
@@ -146,7 +146,7 @@ type Executable struct {
 	// terminated.
 	// The timeout is specified in Go duration format (e.g. 30s, 5m, 1h).
 	//
-	Timeout time.Duration `json:"timeout,omitempty" yaml:"timeout,omitempty" mapstructure:"timeout,omitempty"`
+	Timeout *time.Duration `json:"timeout,omitempty" yaml:"timeout,omitempty" mapstructure:"timeout,omitempty"`
 
 	// Verb corresponds to the JSON schema field "verb".
 	Verb Verb `json:"verb" yaml:"verb" mapstructure:"verb"`

--- a/types/executable/executable.go
+++ b/types/executable/executable.go
@@ -21,8 +21,7 @@ import (
 //go:generate go run github.com/atombender/go-jsonschema@v0.16.0 -et --only-models -p executable -o executable.gen.go --capitalization URI --capitalization URL executable_schema.yaml
 
 const (
-	TmpDirLabel    = "f:tmp"
-	DefaultTimeout = 30 * time.Minute
+	TmpDirLabel = "f:tmp"
 )
 
 type ExecutableList []*Executable
@@ -231,11 +230,10 @@ func (e *Executable) SetDefaults() {
 		e.Visibility = &v
 	}
 
-	if e.Timeout == 0 {
-		e.Timeout = DefaultTimeout
+	if e.Timeout == nil {
 		if v, ok := os.LookupEnv(TimeoutOverrideEnv); ok {
 			if d, err := time.ParseDuration(v); err == nil {
-				e.Timeout = d
+				e.Timeout = &d
 			}
 		}
 	}
@@ -540,7 +538,7 @@ func (e *Executable) MarshalJSON() ([]byte, error) {
 	}{
 		Alias: (*Alias)(e),
 	}
-	if e.Timeout != 0 {
+	if e.Timeout != nil {
 		aux.Timeout = e.Timeout.String()
 	}
 	return json.Marshal(aux)
@@ -562,7 +560,7 @@ func (e *Executable) UnmarshalJSON(data []byte) error {
 		if err != nil {
 			return err
 		}
-		e.Timeout = duration
+		e.Timeout = &duration
 	}
 	return nil
 }

--- a/types/executable/executable_md.go
+++ b/types/executable/executable_md.go
@@ -14,7 +14,7 @@ func execMarkdown(e *Executable) string {
 	if e.Visibility != nil {
 		mkdwn += fmt.Sprintf("**Visibility:** %s\n", *e.Visibility)
 	}
-	if e.Timeout != 0 {
+	if e.Timeout != nil {
 		mkdwn += fmt.Sprintf("**Timeout:** %s\n", e.Timeout.String())
 	}
 	if len(e.Aliases) > 0 {

--- a/types/executable/executable_schema.yaml
+++ b/types/executable/executable_schema.yaml
@@ -624,7 +624,6 @@ properties:
     description: |
       The maximum amount of time the executable is allowed to run before being terminated.
       The timeout is specified in Go duration format (e.g. 30s, 5m, 1h).
-    default: 30m0s
   #### Executable context fields
   workspace:
     type: string


### PR DESCRIPTION
Removed the default value (`30m0s`) for the `Timeout` field in `flowfile_schema.json` and `flowfile.md`. This aligns with the new approach of treating `Timeout` as optional. 