### PR TITLE
feat: add ability to set params via exec arg

### DIFF
--- a/cmd/internal/exec.go
+++ b/cmd/internal/exec.go
@@ -11,6 +11,7 @@ import (
 	"github.com/jahvon/tuikit/views"
 	"github.com/spf13/cobra"
 
+	"github.com/jahvon/flow/cmd/internal/flags"
 	"github.com/jahvon/flow/internal/cache"
 	"github.com/jahvon/flow/internal/context"
 	"github.com/jahvon/flow/internal/io"
@@ -61,6 +62,7 @@ func RegisterExecCmd(ctx *context.Context, rootCmd *cobra.Command) {
 			execFunc(ctx, cmd, verb, args)
 		},
 	}
+	RegisterFlag(ctx, subCmd, *flags.ParameterValueFlag)
 	rootCmd.AddCommand(subCmd)
 }
 
@@ -114,6 +116,7 @@ func execFunc(ctx *context.Context, cmd *cobra.Command, verb executable.Verb, ar
 		))
 	}
 
+	// add args to the env map
 	execArgs := make([]string, 0)
 	if len(args) >= 2 {
 		execArgs = args[1:]
@@ -134,8 +137,12 @@ func execFunc(ctx *context.Context, cmd *cobra.Command, verb executable.Verb, ar
 		envMap = make(map[string]string)
 	}
 
-	setAuthEnv(ctx, cmd, e)
-	textInputs := pendingFormFields(ctx, e)
+	// add --param overrides to the env map
+	paramOverrides := flags.ValueFor[[]string](ctx, cmd, *flags.ParameterValueFlag, false)
+	applyParameterOverrides(paramOverrides, envMap)
+
+	// add values from the prompt param type to the env map
+	textInputs := pendingFormFields(ctx, e, envMap)
 	if len(textInputs) > 0 {
 		form, err := views.NewForm(io.Theme(ctx.Config.Theme.String()), ctx.StdIn(), ctx.StdOut(), textInputs...)
 		if err != nil {
@@ -148,6 +155,8 @@ func execFunc(ctx *context.Context, cmd *cobra.Command, verb executable.Verb, ar
 			envMap[key] = fmt.Sprintf("%v", val)
 		}
 	}
+
+	setAuthEnv(ctx, cmd, e)
 	startTime := time.Now()
 	eng := engine.NewExecEngine()
 	if err := runner.Exec(ctx, e, eng, envMap); err != nil {
@@ -304,36 +313,43 @@ func authRequired(ctx *context.Context, rootExec *executable.Executable) bool {
 }
 
 //nolint:gocognit
-func pendingFormFields(ctx *context.Context, rootExec *executable.Executable) []*views.FormField {
+func pendingFormFields(
+	ctx *context.Context, rootExec *executable.Executable, envMap map[string]string,
+) []*views.FormField {
 	pending := make([]*views.FormField, 0)
 	switch {
 	case rootExec.Exec != nil:
 		for _, param := range rootExec.Exec.Params {
-			if param.Prompt != "" {
+			_, exists := envMap[param.EnvKey]
+			if param.Prompt != "" && !exists {
 				pending = append(pending, &views.FormField{Key: param.EnvKey, Title: param.Prompt})
 			}
 		}
 	case rootExec.Launch != nil:
 		for _, param := range rootExec.Launch.Params {
-			if param.Prompt != "" {
+			_, exists := envMap[param.EnvKey]
+			if param.Prompt != "" && !exists {
 				pending = append(pending, &views.FormField{Key: param.EnvKey, Title: param.Prompt})
 			}
 		}
 	case rootExec.Request != nil:
 		for _, param := range rootExec.Request.Params {
-			if param.Prompt != "" {
+			_, exists := envMap[param.EnvKey]
+			if param.Prompt != "" && !exists {
 				pending = append(pending, &views.FormField{Key: param.EnvKey, Title: param.Prompt})
 			}
 		}
 	case rootExec.Render != nil:
 		for _, param := range rootExec.Render.Params {
-			if param.Prompt != "" {
+			_, exists := envMap[param.EnvKey]
+			if param.Prompt != "" && !exists {
 				pending = append(pending, &views.FormField{Key: param.EnvKey, Title: param.Prompt})
 			}
 		}
 	case rootExec.Serial != nil:
 		for _, param := range rootExec.Serial.Params {
-			if param.Prompt != "" {
+			_, exists := envMap[param.EnvKey]
+			if param.Prompt != "" && !exists {
 				pending = append(pending, &views.FormField{Key: param.EnvKey, Title: param.Prompt})
 			}
 		}
@@ -343,7 +359,7 @@ func pendingFormFields(ctx *context.Context, rootExec *executable.Executable) []
 				if err != nil {
 					continue
 				}
-				childPending := pendingFormFields(ctx, childExec)
+				childPending := pendingFormFields(ctx, childExec, envMap)
 				pending = append(pending, childPending...)
 			}
 		}
@@ -359,12 +375,23 @@ func pendingFormFields(ctx *context.Context, rootExec *executable.Executable) []
 				if err != nil {
 					continue
 				}
-				childPending := pendingFormFields(ctx, childExec)
+				childPending := pendingFormFields(ctx, childExec, envMap)
 				pending = append(pending, childPending...)
 			}
 		}
 	}
 	return pending
+}
+
+func applyParameterOverrides(overrides []string, envMap map[string]string) {
+	for _, override := range overrides {
+		parts := strings.SplitN(override, "=", 2)
+		if len(parts) != 2 {
+			continue // skip invalid overrides
+		}
+		key, value := parts[0], parts[1]
+		envMap[key] = value
+	}
 }
 
 var (

--- a/cmd/internal/flags/types.go
+++ b/cmd/internal/flags/types.go
@@ -175,3 +175,11 @@ var StoreAllFlag = &Metadata{
 	Usage:   "Force clear all stored data",
 	Default: false,
 }
+
+var ParameterValueFlag = &Metadata{
+	Name:      "param",
+	Shorthand: "p",
+	Usage: "Set a parameter value by env key. (i.e. KEY=value) Use multiple times to set multiple parameters." +
+		"This will override any existing parameter values defined for the executable.",
+	Default: []string{},
+}

--- a/docs/guide/executable.md
+++ b/docs/guide/executable.md
@@ -157,6 +157,13 @@ parameter type sets a static value for the environment variable.
 
 _This example used the `exec` type, but the `params` field can be used with any executable type._
 
+You can override any environment variable defined in the `params` or provide additional ones by using the `--param` flag
+when running the executable:
+
+```shell
+flow deploy devbox --param API_TOKEN=token --param DRY_RUN=true --param VERBOSE=value
+```
+
 **Args**
 
 

--- a/internal/runner/env.go
+++ b/internal/runner/env.go
@@ -38,6 +38,11 @@ func ResolveParameterValue(
 	param executable.Parameter,
 	promptedEnv map[string]string,
 ) (string, error) {
+	if val, found := promptedEnv[param.EnvKey]; found {
+		// existing values win - these could come in as a param override from the CLI
+		return val, nil
+	}
+
 	switch {
 	case param.Text == "" && param.SecretRef == "" && param.Prompt == "":
 		return "", nil

--- a/tests/exec_cmd_e2e_test.go
+++ b/tests/exec_cmd_e2e_test.go
@@ -34,4 +34,19 @@ var _ = Describe("exec e2e", func() {
 		Entry("nameless example", ""),
 		Entry("request with transformation", "examples:request-with-transform"),
 	)
+
+	When("param overrides are provided", func() {
+		It("should run the executable with the provided overrides", func() {
+			runner := utils.NewE2ECommandRunner()
+			stdOut := ctx.StdOut()
+			Expect(runner.Run(
+				ctx, "exec", "examples:with-params",
+				"--param", "PARAM1=value1", "--param", "PARAM2=value2", "--param", "PARAM3=value3",
+			)).To(Succeed())
+			out, _ := readFileContent(stdOut)
+			Expect(out).To(ContainSubstring("value1"))
+			Expect(out).To(ContainSubstring("value2"))
+			Expect(out).To(ContainSubstring("value3"))
+		})
+	})
 })

--- a/tests/utils/context.go
+++ b/tests/utils/context.go
@@ -4,6 +4,7 @@ import (
 	stdCtx "context"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	tuikitIO "github.com/jahvon/tuikit/io"
@@ -42,7 +43,14 @@ func NewContext(ctx stdCtx.Context, t ginkgo.FullGinkgoTInterface) *context.Cont
 		tuikitIO.WithTheme(io.Theme("")),
 		tuikitIO.WithMode(tuikitIO.Text),
 		tuikitIO.WithExitFunc(func() {
-			t.Fatalf("logger exit called")
+			// include the colling function/line
+			_, file, line, ok := runtime.Caller(1)
+			if ok {
+				file = filepath.Base(file)
+				t.Logf("logger exit called from %s:%d", file, line)
+			} else {
+				t.Logf("logger exit called")
+			}
 		}),
 	)
 	ctxx := newTestContext(ctx, t, logger, stdIn, stdOut)

--- a/tools/builder/exec.go
+++ b/tools/builder/exec.go
@@ -180,13 +180,16 @@ func ExecWithParams(opts ...Option) *executable.Executable {
 	for _, param := range params {
 		switch {
 		case param.Text != "":
-			paramCmds = append(paramCmds, fmt.Sprintf("echo 'key=%s, value=%s'", param.EnvKey, param.Text))
+			paramCmds = append(paramCmds, fmt.Sprintf(`echo "key=%s, value=$%[1]s"`, param.EnvKey))
 		case param.SecretRef != "":
-			paramCmds = append(paramCmds, fmt.Sprintf("echo 'key=%s, secret=%s'", param.EnvKey, param.SecretRef))
+			paramCmds = append(
+				paramCmds,
+				fmt.Sprintf(`echo "key=%s, secret=%s, value=$%[1]s"`, param.EnvKey, param.SecretRef),
+			)
 		case param.Prompt != "":
 			paramCmds = append(
 				paramCmds,
-				fmt.Sprintf("echo 'key=%s, prompt=%s', value=$%[1]s", param.EnvKey, param.Prompt),
+				fmt.Sprintf(`echo "key=%s, prompt=%s value=$%[1]s"`, param.EnvKey, param.Prompt),
 			)
 		}
 	}


### PR DESCRIPTION
This pull request introduces enhancements to the `exec` command functionality. The most significant change includes adding support for the `--param` flag to override environment variables. This allows skipping of the `prompt` form whenever a value is overriden. Note: values set this way now take presence over anything defined in the config.

_Note to self: this should help with testing and the desktop integration but I may need to think about how this relates to the `args` on an executable_