### PR TITLE
fix: disable markdown viewer when rendering as non-interactive

### DIFF
--- a/cmd/internal/helpers.go
+++ b/cmd/internal/helpers.go
@@ -61,7 +61,7 @@ func TUIEnabled(ctx *context.Context, cmd *cobra.Command) bool {
 		format := flags.ValueFor[string](cmd, *flags.OutputFormatFlag, false)
 		formatDisabled = format == "yaml" || format == "yml" || format == "json"
 	}
-	envDisabled, _ := strconv.ParseBool(os.Getenv("DISABLE_FLOW_INTERACTIVE"))
+	envDisabled, _ := strconv.ParseBool(os.Getenv(flowIO.DisableInteractiveEnvKey))
 	return !formatDisabled && !envDisabled && ctx.Config.ShowTUI()
 }
 

--- a/internal/io/io.go
+++ b/internal/io/io.go
@@ -2,8 +2,9 @@ package io
 
 import "os"
 
+const DisableInteractiveEnvKey = "DISABLE_FLOW_INTERACTIVE"
+
 var (
 	Stdout = os.Stdout
-	Stderr = os.Stderr
 	Stdin  = os.Stdin
 )

--- a/internal/runner/render/render.go
+++ b/internal/runner/render/render.go
@@ -15,6 +15,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/flowexec/flow/internal/context"
+	"github.com/flowexec/flow/internal/io"
 	"github.com/flowexec/flow/internal/logger"
 	"github.com/flowexec/flow/internal/runner"
 	"github.com/flowexec/flow/internal/runner/engine"
@@ -107,7 +108,13 @@ func (r *renderRunner) Exec(
 	}
 
 	logger.Log().Infof("Rendering content from file %s", contentFile)
-	filename := filepath.Base(contentFile)
+
+	if os.Getenv(io.DisableInteractiveEnvKey) != "" {
+		logger.Log().Print("### Rendered Content Start ###")
+		logger.Log().Print(buff.String())
+		logger.Log().Print("### Rendered Content End ###")
+		return nil
+	}
 
 	if err := ctx.TUIContainer.Start(); err != nil {
 		return errors.Wrapf(err, "unable to open viewer")
@@ -116,6 +123,7 @@ func (r *renderRunner) Exec(
 		ctx.TUIContainer.WaitForExit()
 	}()
 
+	filename := filepath.Base(contentFile)
 	ctx.TUIContainer.SetState("file", filename)
 	return ctx.TUIContainer.SetView(views.NewMarkdownView(ctx.TUIContainer.RenderState(), buff.String()))
 }

--- a/internal/utils/env/env.go
+++ b/internal/utils/env/env.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/flowexec/flow/internal/context"
 	"github.com/flowexec/flow/internal/filesystem"
+	"github.com/flowexec/flow/internal/io"
 	"github.com/flowexec/flow/internal/utils"
 	"github.com/flowexec/flow/types/executable"
 )
@@ -206,9 +207,9 @@ func DefaultEnv(ctx *context.Context, executable *executable.Executable) map[str
 	envMap["FLOW_WORKSPACE_PATH"] = executable.WorkspacePath()
 	envMap["FLOW_CONFIG_PATH"] = filesystem.ConfigDirPath()
 	envMap["FLOW_CACHE_PATH"] = filesystem.CachedDataDirPath()
-	envMap["DISABLE_FLOW_INTERACTIVE"] = "true"
-	if interactive := os.Getenv("DISABLE_FLOW_INTERACTIVE"); interactive != "" {
-		envMap["DISABLE_FLOW_INTERACTIVE"] = interactive
+	envMap[io.DisableInteractiveEnvKey] = "true"
+	if interactive := os.Getenv(io.DisableInteractiveEnvKey); interactive != "" {
+		envMap[io.DisableInteractiveEnvKey] = interactive
 	}
 	return envMap
 }

--- a/internal/utils/env/env_test.go
+++ b/internal/utils/env/env_test.go
@@ -11,6 +11,7 @@ import (
 	"go.uber.org/mock/gomock"
 
 	"github.com/flowexec/flow/internal/context"
+	"github.com/flowexec/flow/internal/io"
 	"github.com/flowexec/flow/internal/logger"
 	"github.com/flowexec/flow/internal/utils/env"
 	"github.com/flowexec/flow/types/config"
@@ -300,7 +301,7 @@ var _ = Describe("Env", func() {
 			Expect(envMap["FLOW_CURRENT_WORKSPACE"]).To(Equal(wsName))
 			Expect(envMap["FLOW_CURRENT_NAMESPACE"]).To(Equal(nsName))
 			Expect(envMap["FLOW_EXECUTABLE_NAME"]).To(Equal(execName))
-			Expect(envMap["DISABLE_FLOW_INTERACTIVE"]).To(Equal("true"))
+			Expect(envMap[io.DisableInteractiveEnvKey]).To(Equal("true"))
 			// TODO: Add more assertions for other keys in the environment map
 		})
 	})


### PR DESCRIPTION
Small change to the render runner that prints the rendered output instead of starting the markdown viewer when interactive mode is disabled.