### PR TITLE
feat(exec): show container config in executable detail views

### DIFF
--- a/internal/io/executable/detail.go
+++ b/internal/io/executable/detail.go
@@ -152,6 +152,9 @@ func shellExecConfig(e *executable.ExecutableEnvironment, s *executable.ExecExec
 	} else if s.File != "" {
 		md += fmt.Sprintf("**File:** `%s`\n\n", s.File)
 	}
+	if container := executable.ContainerConfigMarkdown(s.Container); container != "" {
+		md += container + "\n"
+	}
 	md += envTable(e)
 	return md
 }

--- a/types/executable/container.go
+++ b/types/executable/container.go
@@ -117,3 +117,46 @@ func (v ExecContainerVolume) Parts() (host, container, options string, err error
 func isDriveLetter(b byte) bool {
 	return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z')
 }
+
+// ContainerConfigMarkdown renders the container configuration as a markdown
+// block (a bold label followed by a bullet list). It returns "" when no
+// container is configured, so callers can conditionally append it. Effective
+// values are shown, so defaults applied by SetDefaults (runtime, workspace
+// mount) are visible.
+func ContainerConfigMarkdown(c *ExecContainer) string {
+	if c == nil {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString("**Container**\n")
+	fmt.Fprintf(&b, "- Image: `%s`\n", c.Image)
+	if c.Runtime != "" {
+		fmt.Fprintf(&b, "- Runtime: %s\n", c.Runtime)
+	}
+	if c.Workdir != "" {
+		fmt.Fprintf(&b, "- Workdir: `%s`\n", c.Workdir)
+	}
+	if c.MountWorkspace != "" {
+		fmt.Fprintf(&b, "- Workspace mount: `%s`\n", c.MountWorkspace)
+	}
+	for _, v := range c.Volumes {
+		fmt.Fprintf(&b, "- Volume: `%s`\n", string(v))
+	}
+	if c.User != nil {
+		fmt.Fprintf(&b, "- User: `%s`\n", *c.User)
+	}
+	if c.Network != "" {
+		fmt.Fprintf(&b, "- Network: `%s`\n", c.Network)
+	}
+	if c.Entrypoint != nil {
+		if *c.Entrypoint == "" {
+			b.WriteString("- Entrypoint: image default\n")
+		} else {
+			fmt.Fprintf(&b, "- Entrypoint: `%s`\n", *c.Entrypoint)
+		}
+	}
+	if !c.EnvInherited() {
+		b.WriteString("- Inherit env: false\n")
+	}
+	return b.String()
+}

--- a/types/executable/container_test.go
+++ b/types/executable/container_test.go
@@ -1,6 +1,7 @@
 package executable_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/flowexec/flow/v2/types/executable"
@@ -73,6 +74,40 @@ func TestContainerResolveEntrypoint(t *testing.T) {
 				t.Errorf("ResolveEntrypoint() = (%q, %v), want (%q, %v)", entry, override, tc.wantEntry, tc.wantOverride)
 			}
 		})
+	}
+}
+
+func TestContainerConfigMarkdown(t *testing.T) {
+	if got := executable.ContainerConfigMarkdown(nil); got != "" {
+		t.Errorf("nil container should render empty, got %q", got)
+	}
+
+	user := "1000:1000"
+	imageDefault := ""
+	c := &executable.ExecContainer{
+		Image:   "golang:1.21-alpine",
+		Volumes: []executable.ExecContainerVolume{"//cache:/cache"},
+		User:    &user,
+		Network: "host",
+		// entrypoint explicitly empty => image default
+		Entrypoint: &imageDefault,
+	}
+	c.SetDefaults()
+	got := executable.ContainerConfigMarkdown(c)
+
+	for _, want := range []string{
+		"**Container**",
+		"Image: `golang:1.21-alpine`",
+		"Runtime: auto",
+		"Workspace mount: `/workspace`",
+		"Volume: `//cache:/cache`",
+		"User: `1000:1000`",
+		"Network: `host`",
+		"Entrypoint: image default",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("markdown missing %q; got:\n%s", want, got)
+		}
 	}
 }
 

--- a/types/executable/executable_md.go
+++ b/types/executable/executable_md.go
@@ -102,6 +102,9 @@ func shellExecMarkdown(e *ExecutableEnvironment, s *ExecExecutableType) string {
 	} else if s.File != "" {
 		mkdwn += fmt.Sprintf("**File:** `%s`\n", s.File)
 	}
+	if container := ContainerConfigMarkdown(s.Container); container != "" {
+		mkdwn += "\n" + container
+	}
 	mkdwn += execEnvTable(e)
 
 	return mkdwn


### PR DESCRIPTION
## Summary

Follow-up to the containerized-executions feature (#407): neither executable detail view surfaced the `container:` config.

- **`flow get`** (markdown) — `shellExecMarkdown` rendered `dir`/`logMode`/`cmd`/`file` but not `container`.
- **`flow browse`** (TUI detail) — `shellExecConfig` had the same gap.

Adds a shared `executable.ContainerConfigMarkdown` renderer and wires it into both paths, so image, runtime, workspace mount, volumes, user, network, and entrypoint are shown. Effective values are displayed, so `SetDefaults`-applied fields (runtime `auto`, mount `/workspace`) are visible.

Example rendered block:

```
**Container**
- Image: `golang:1.21-alpine`
- Runtime: auto
- Workspace mount: `/workspace`
- Volume: `//cache:/cache`
- User: `1000:1000`
- Network: `host`
- Entrypoint: image default
```

## Testing

- Unit test for `ContainerConfigMarkdown` (nil → empty; all fields present; `entrypoint: ""` → "image default").
- Verified the full `Executable.Markdown()` path includes the block.
- Full unit suite + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)