### PR TITLE
feat: agent execution observability — run tools, provenance, and lifecycle history

### DIFF
--- a/.claude/skills/flow-context/SKILL.md
+++ b/.claude/skills/flow-context/SKILL.md
@@ -1,25 +1,24 @@
 ---
 name: flow-context
-description: This project uses flow for automation. When asked to build, test, run, deploy, lint, generate, or perform any dev task, check for a flow executable before falling back to raw shell commands.
+description: This project uses flow for automation. When asked to build, test, run, deploy, lint, generate, or perform any dev task — or to run any one-off shell command — prefer the flow MCP tools over raw Bash so the work runs with workspace env/secrets and is recorded in flow's history.
 user-invocable: false
 ---
 
-This repository uses **flow** for all development automation. The `mcp__flow__*` MCP tools are available.
+This repository uses **flow** for all development automation. The `mcp__flow__*` MCP tools are available — prefer them over raw `Bash` for anything runnable, so it executes with the workspace's environment and secrets and is captured in flow's execution history.
 
-## Default behavior for dev tasks
+## Running work — pick the closest tool
 
-When the user asks to build, test, deploy, lint, generate, or run anything:
-
-1. Call `mcp__flow__list_executables` first — check whether a flow executable already handles the task
-2. If found, use `mcp__flow__execute` with the matching verb and name — do not run a raw shell command
-3. Only fall back to `Bash` if no flow executable exists for the task
+1. **Named task?** (build, test, lint, validate, generate, deploy, …) → `mcp__flow__list_executables` to find it, then `mcp__flow__execute` with its verb + name. Don't hand-roll a shell command a flow executable already covers.
+2. **Arbitrary one-off command?** (a `git ...`, `go test ./...`, a script) → `mcp__flow__run_command` with the command and a short `label`. This is preferred over raw `Bash`: it runs with workspace env/secrets and lands in `flow logs` with provenance. Pass `commands` (array) + `mode` (`serial`/`parallel`) to run several in one call.
+3. **Something richer than one command?** (a serial/parallel batch, an HTTP `request`) → `mcp__flow__run_executable` with an inline `spec`.
+4. Only fall back to `Bash` when a command genuinely shouldn't be recorded or flow isn't the right tool (e.g. interactive/TTY programs).
 
 ## Key executables in this repo
 
-Common refs: `test unit`, `test e2e`, `lint`, `validate`, `generate`, `build binary`
+Common refs: `test unit`, `test e2e`, `lint`, `validate`, `generate`, `build binary`. Use `mcp__flow__list_executables` to discover current names — don't assume.
 
-Use `mcp__flow__list_executables` to discover the full list and current names — don't assume.
+## Context & authoring
 
-## When to call get_info
-
-Call `mcp__flow__get_info` at the start of a session or when you need schema URLs to author `.flow` files.
+- Call `mcp__flow__get_info` at the start of a session, or when you need schema URLs to author `.flow` files.
+- Author or edit flow files with `mcp__flow__write_flowfile` (validates against the schema server-side) rather than writing YAML by hand.
+- Runs are scoped to the current workspace by default; `run_command`/`run_executable` accept an optional `workspace` to target another without switching the global current workspace.

--- a/.claude/skills/flow-context/SKILL.md
+++ b/.claude/skills/flow-context/SKILL.md
@@ -22,3 +22,4 @@ Common refs: `test unit`, `test e2e`, `lint`, `validate`, `generate`, `build bin
 - Call `mcp__flow__get_info` at the start of a session, or when you need schema URLs to author `.flow` files.
 - Author or edit flow files with `mcp__flow__write_flowfile` (validates against the schema server-side) rather than writing YAML by hand.
 - Runs are scoped to the current workspace by default; `run_command`/`run_executable` accept an optional `workspace` to target another without switching the global current workspace.
+- To review what you've run this session, call `mcp__flow__get_execution_logs` with `mine: true`; `source`/`session`/`status` filter history more broadly (also `flow logs --source mcp --session <id>`).

--- a/cmd/internal/exec.go
+++ b/cmd/internal/exec.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"errors"
 	"fmt"
+	stdio "io"
 	"os"
 	osExec "os/exec"
 	"path/filepath"
@@ -10,6 +11,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"gopkg.in/yaml.v3"
 
 	tuikitIO "github.com/flowexec/tuikit/io"
 	"github.com/flowexec/tuikit/views"
@@ -81,6 +83,12 @@ func RegisterExecCmd(ctx *context.Context, rootCmd *cobra.Command) {
 	RegisterFlag(ctx, subCmd, *flags.ParameterValueFlag)
 	RegisterFlag(ctx, subCmd, *flags.LogModeFlag)
 	RegisterFlag(ctx, subCmd, *flags.BackgroundFlag)
+	RegisterFlag(ctx, subCmd, *flags.CmdFlag)
+	RegisterFlag(ctx, subCmd, *flags.CmdModeFlag)
+	RegisterFlag(ctx, subCmd, *flags.LabelFlag)
+	RegisterFlag(ctx, subCmd, *flags.CmdDirFlag)
+	RegisterFlag(ctx, subCmd, *flags.SpecFlag)
+	RegisterFlag(ctx, subCmd, *flags.RunWorkspaceFlag)
 	rootCmd.AddCommand(subCmd)
 }
 
@@ -103,38 +111,22 @@ func execFunc(ctx *context.Context, cmd *cobra.Command, verb executable.Verb, ar
 		errhandler.HandleFatal(ctx, cmd, err)
 	}
 
-	var ref executable.Ref
-	if len(args) == 0 {
-		ref = context.ExpandRef(ctx, executable.NewRef("", verb))
-	} else {
-		idArg := args[0]
-		ref = context.ExpandRef(ctx, executable.NewRef(idArg, verb))
+	// Ad-hoc / transient modes: run something not resolved from the executable cache.
+	adhocCmds := flags.ValueFor[[]string](cmd, *flags.CmdFlag, false)
+	spec := flags.ValueFor[string](cmd, *flags.SpecFlag, false)
+	switch {
+	case len(adhocCmds) > 0 && spec != "":
+		errhandler.HandleUsage(ctx, cmd, "--cmd and --spec are mutually exclusive")
+		return
+	case len(adhocCmds) > 0:
+		execAdHoc(ctx, cmd, verb, adhocCmds)
+		return
+	case spec != "":
+		execTransientSpec(ctx, cmd, verb, spec)
+		return
 	}
 
-	e, err := ctx.ExecutableCache.GetExecutableByRef(ref)
-	if err != nil && errors.Is(err, flowErrors.NewExecutableNotFoundError(ref.String())) {
-		logger.Log().Debugf("Executable %s not found in cache, syncing cache", ref)
-		if err := ctx.ExecutableCache.Update(); err != nil {
-			errhandler.HandleFatal(ctx, cmd, err)
-		}
-		e, err = ctx.ExecutableCache.GetExecutableByRef(ref)
-	}
-	if err != nil {
-		errhandler.HandleFatal(ctx, cmd, err)
-	}
-
-	if err := e.Validate(); err != nil {
-		errhandler.HandleFatal(ctx, cmd, err)
-	}
-
-	if ctx.CurrentWorkspace != nil && !e.IsExecutableFromWorkspace(ctx.CurrentWorkspace.AssignedName()) {
-		errhandler.HandleFatal(ctx, cmd, fmt.Errorf(
-			"executable '%s' belongs to workspace '%s' and cannot be run from the current workspace '%s'",
-			ref,
-			e.Workspace(),
-			ctx.Config.CurrentWorkspace,
-		))
-	}
+	e, ref := resolveExecutableForRun(ctx, cmd, verb, args)
 
 	// Handle --background: spawn a detached child process and return immediately.
 	background := flags.ValueFor[bool](cmd, *flags.BackgroundFlag, false)
@@ -165,12 +157,15 @@ func execFunc(ctx *context.Context, cmd *cobra.Command, verb executable.Verb, ar
 	}
 
 	startTime := time.Now()
+	prov := runProvenanceFromEnv()
+	recordRunStart(ctx, ref, startTime, prov, "", "")
+
 	eng := engine.NewExecEngine()
 	runErr := runner.Exec(ctx, e, eng, envMap, execArgs)
 	dur := time.Since(startTime)
 
 	cleanupProcessStore(ctx)
-	recordExecution(ctx, ref, startTime, dur, runErr)
+	recordExecution(ctx, ref, startTime, dur, runErr, prov, "", "")
 
 	// Update background run record if this is a child process.
 	if bgRunID != "" {
@@ -182,6 +177,299 @@ func execFunc(ctx *context.Context, cmd *cobra.Command, verb executable.Verb, ar
 	}
 	logger.Log().Debug(fmt.Sprintf("%s flow completed", ref), "Elapsed", dur.Round(time.Millisecond))
 	sendCompletionNotifications(ctx, cmd, dur)
+}
+
+// resolveExecutableForRun resolves the target executable and ref from the verb and args, syncing the
+// cache on a miss and validating workspace membership. Fatal on any resolution/validation failure.
+func resolveExecutableForRun(
+	ctx *context.Context, cmd *cobra.Command, verb executable.Verb, args []string,
+) (*executable.Executable, executable.Ref) {
+	var ref executable.Ref
+	if len(args) == 0 {
+		ref = context.ExpandRef(ctx, executable.NewRef("", verb))
+	} else {
+		ref = context.ExpandRef(ctx, executable.NewRef(args[0], verb))
+	}
+
+	e, err := ctx.ExecutableCache.GetExecutableByRef(ref)
+	if err != nil && errors.Is(err, flowErrors.NewExecutableNotFoundError(ref.String())) {
+		logger.Log().Debugf("Executable %s not found in cache, syncing cache", ref)
+		if err := ctx.ExecutableCache.Update(); err != nil {
+			errhandler.HandleFatal(ctx, cmd, err)
+		}
+		e, err = ctx.ExecutableCache.GetExecutableByRef(ref)
+	}
+	if err != nil {
+		errhandler.HandleFatal(ctx, cmd, err)
+	}
+
+	if err := e.Validate(); err != nil {
+		errhandler.HandleFatal(ctx, cmd, err)
+	}
+
+	if ctx.CurrentWorkspace != nil && !e.IsExecutableFromWorkspace(ctx.CurrentWorkspace.AssignedName()) {
+		errhandler.HandleFatal(ctx, cmd, fmt.Errorf(
+			"executable '%s' belongs to workspace '%s' and cannot be run from the current workspace '%s'",
+			ref,
+			e.Workspace(),
+			ctx.Config.CurrentWorkspace,
+		))
+	}
+	return e, ref
+}
+
+// execAdHoc runs one or more arbitrary shell commands through flow as a transient, in-memory
+// executable. Nothing is written to disk as a flowfile; the run flows through the normal engine
+// (workspace env, vault secrets, logging) and is recorded in history with the command text and an
+// optional label so it shows up in `flow logs` like a named executable. A single command becomes an
+// `exec` executable; multiple commands become a `serial` or `parallel` executable (per --mode).
+func execAdHoc(ctx *context.Context, cmd *cobra.Command, verb executable.Verb, commands []string) {
+	label := flags.ValueFor[string](cmd, *flags.LabelFlag, false)
+	dir := flags.ValueFor[string](cmd, *flags.CmdDirFlag, false)
+	if dir == "" {
+		if wd, err := os.Getwd(); err == nil {
+			dir = wd
+		}
+	}
+
+	// Default ad-hoc output to raw command output (Text mode routes stdout/stderr straight through
+	// without flow's timestamp/level/color decoration), so callers — especially agents via the MCP
+	// run_command tool — get the command's actual output. An explicit --log-mode still wins.
+	logMode := tuikitIO.Text
+	if lm := flags.ValueFor[string](cmd, *flags.LogModeFlag, false); lm != "" {
+		logMode = tuikitIO.LogMode(lm)
+	}
+
+	joined := strings.Join(commands, "\n")
+	e := &executable.Executable{
+		Verb:        verb,
+		Name:        adHocName(label, joined),
+		Description: label,
+	}
+	if len(commands) == 1 {
+		e.Exec = &executable.ExecExecutableType{
+			Cmd:     commands[0],
+			Dir:     executable.Directory(dir),
+			LogMode: logMode,
+		}
+	} else {
+		steps := make(executable.SerialRefConfigList, len(commands))
+		for i, c := range commands {
+			steps[i] = executable.SerialRefConfig{Cmd: c}
+		}
+		mode := flags.ValueFor[string](cmd, *flags.CmdModeFlag, false)
+		if mode == "parallel" {
+			pSteps := make(executable.ParallelRefConfigList, len(commands))
+			for i, c := range commands {
+				pSteps[i] = executable.ParallelRefConfig{Cmd: c}
+			}
+			e.Parallel = &executable.ParallelExecutableType{Execs: pSteps}
+		} else {
+			e.Serial = &executable.SerialExecutableType{Execs: steps}
+		}
+	}
+	setTransientContext(ctx, cmd, e, dir)
+	runTransientExecutable(ctx, cmd, e, joined, label)
+}
+
+// execTransientSpec runs a transient executable parsed from an inline definition (--spec). Unlike
+// --cmd, the spec can be any executable type (exec, serial, parallel, request, render, launch); it
+// is never written to disk but runs through the normal engine and is recorded in history.
+func execTransientSpec(ctx *context.Context, cmd *cobra.Command, verb executable.Verb, spec string) {
+	content, err := resolveSpecContent(spec)
+	if err != nil {
+		errhandler.HandleFatal(ctx, cmd, err)
+	}
+
+	e := &executable.Executable{}
+	if err := yaml.Unmarshal([]byte(content), e); err != nil {
+		errhandler.HandleUsage(ctx, cmd, "invalid executable spec: %v", err)
+		return
+	}
+	runDir, _ := os.Getwd()
+	setTransientContext(ctx, cmd, e, runDir)
+	e.SetDefaults()
+	if e.Verb == "" {
+		e.Verb = verb
+	}
+	if err := e.Validate(); err != nil {
+		errhandler.HandleUsage(ctx, cmd, "invalid executable spec: %v", err)
+		return
+	}
+
+	label := flags.ValueFor[string](cmd, *flags.LabelFlag, false)
+	if label == "" {
+		label = e.Name
+	}
+	runTransientExecutable(ctx, cmd, e, "", label)
+}
+
+// resolveSpecContent resolves a --spec value into raw definition content: '-' reads stdin,
+// a leading '@' reads the named file, and anything else is treated as inline content.
+func resolveSpecContent(spec string) (string, error) {
+	switch {
+	case spec == "-":
+		data, err := stdio.ReadAll(os.Stdin)
+		if err != nil {
+			return "", fmt.Errorf("unable to read spec from stdin: %w", err)
+		}
+		return string(data), nil
+	case strings.HasPrefix(spec, "@"):
+		data, err := os.ReadFile(filepath.Clean(spec[1:]))
+		if err != nil {
+			return "", fmt.Errorf("unable to read spec file: %w", err)
+		}
+		return string(data), nil
+	default:
+		return spec, nil
+	}
+}
+
+// setTransientContext anchors a transient executable to a resolved workspace so it runs with that
+// workspace's environment (and secrets), even though it is not backed by a flowfile. The workspace
+// is resolved per-run (explicit --workspace, then the workspace containing runDir, then the global
+// current) WITHOUT ever mutating the global current workspace. When the resolved workspace differs
+// from the global current, a notice is emitted so the run's context is visible/auditable.
+func setTransientContext(ctx *context.Context, cmd *cobra.Command, e *executable.Executable, runDir string) {
+	wsName, wsPath := resolveRunWorkspace(ctx, cmd, runDir)
+
+	currentName := ""
+	if ctx.CurrentWorkspace != nil {
+		currentName = ctx.CurrentWorkspace.AssignedName()
+	}
+	if wsName != "" && wsName != currentName {
+		logger.Log().Infof("Running in workspace '%s' (current workspace is '%s')", wsName, currentName)
+	}
+
+	var flowFilePath string
+	if wsPath != "" {
+		flowFilePath = filepath.Join(wsPath, "flow.yaml")
+	}
+	e.SetContext(wsName, wsPath, ctx.Config.CurrentNamespace, flowFilePath)
+}
+
+// resolveRunWorkspace picks the workspace a transient run should use, in priority order:
+// an explicit --workspace flag, then the workspace whose location contains runDir (longest match),
+// then the global current workspace. It never changes the global current workspace.
+func resolveRunWorkspace(ctx *context.Context, cmd *cobra.Command, runDir string) (name, path string) {
+	wsList, err := ctx.WorkspacesCache.GetWorkspaceConfigList()
+	if err != nil {
+		logger.Log().Debugf("unable to load workspaces for transient run resolution: %v", err)
+	}
+
+	if explicit := flags.ValueFor[string](cmd, *flags.RunWorkspaceFlag, false); explicit != "" {
+		if ws := wsList.FindByName(explicit); ws != nil {
+			return ws.AssignedName(), ws.Location()
+		}
+		errhandler.HandleUsage(ctx, cmd, "unknown workspace %q", explicit)
+	}
+
+	if ws := workspaceForPath(wsList, runDir); ws != nil {
+		return ws.AssignedName(), ws.Location()
+	}
+
+	if ctx.CurrentWorkspace != nil {
+		return ctx.CurrentWorkspace.AssignedName(), ctx.CurrentWorkspace.Location()
+	}
+	return "", ""
+}
+
+// workspaceForPath returns the workspace whose location is the longest prefix of dir, or nil.
+func workspaceForPath(wsList workspace.WorkspaceList, dir string) *workspace.Workspace {
+	if dir == "" {
+		return nil
+	}
+	abs, err := filepath.Abs(dir)
+	if err != nil {
+		abs = dir
+	}
+	var best *workspace.Workspace
+	for _, ws := range wsList {
+		loc := ws.Location()
+		if loc == "" {
+			continue
+		}
+		if abs == loc || strings.HasPrefix(abs, loc+string(filepath.Separator)) {
+			if best == nil || len(loc) > len(best.Location()) {
+				best = ws
+			}
+		}
+	}
+	return best
+}
+
+// runTransientExecutable runs an already-constructed, in-memory executable through the normal engine
+// and records it in history with the given command/label provenance. Shared by --cmd and --spec.
+func runTransientExecutable(
+	ctx *context.Context, cmd *cobra.Command, e *executable.Executable, command, label string,
+) {
+	ref := e.Ref()
+
+	if ctx.DataStore != nil {
+		if err := ctx.DataStore.CreateProcessBucket(ref.String()); err != nil {
+			errhandler.HandleFatal(ctx, cmd, err)
+		}
+		_ = os.Setenv(store.BucketEnv, ref.String())
+	}
+
+	envMap := buildExecEnv(ctx, cmd, e)
+
+	startTime := time.Now()
+	prov := runProvenanceFromEnv()
+	recordRunStart(ctx, ref, startTime, prov, command, label)
+
+	eng := engine.NewExecEngine()
+	runErr := runner.Exec(ctx, e, eng, envMap, nil)
+	dur := time.Since(startTime)
+
+	cleanupProcessStore(ctx)
+	recordExecution(ctx, ref, startTime, dur, runErr, prov, command, label)
+
+	if runErr != nil {
+		errhandler.HandleFatal(ctx, cmd, runErr)
+	}
+	logger.Log().Debug(fmt.Sprintf("transient executable completed: %s", ref), "Elapsed", dur.Round(time.Millisecond))
+	sendCompletionNotifications(ctx, cmd, dur)
+}
+
+// adHocName derives a short, ref-safe name for a transient command run, preferring the label and
+// falling back to the command's first token.
+func adHocName(label, command string) string {
+	base := label
+	if base == "" {
+		if fields := strings.Fields(command); len(fields) > 0 {
+			base = fields[0]
+		}
+	}
+	slug := slugify(base)
+	if slug == "" {
+		slug = "command"
+	}
+	return "adhoc-" + slug
+}
+
+// slugify reduces a string to lowercase alphanumerics separated by single dashes, capped at 40 chars.
+func slugify(s string) string {
+	s = strings.ToLower(strings.TrimSpace(s))
+	var b strings.Builder
+	prevDash := false
+	for _, r := range s {
+		switch {
+		case (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9'):
+			b.WriteRune(r)
+			prevDash = false
+		default:
+			if !prevDash && b.Len() > 0 {
+				b.WriteByte('-')
+				prevDash = true
+			}
+		}
+	}
+	out := strings.Trim(b.String(), "-")
+	if len(out) > 40 {
+		out = strings.Trim(out[:40], "-")
+	}
+	return out
 }
 
 // launchBackground spawns a detached flow process for the given executable and returns immediately.
@@ -335,15 +623,76 @@ func cleanupProcessStore(ctx *context.Context) {
 	}
 }
 
-func recordExecution(ctx *context.Context, ref executable.Ref, startTime time.Time, dur time.Duration, runErr error) {
+// provenance bundles who/what launched a run, recorded on its execution record.
+type provenance struct {
+	source, client, session string
+}
+
+// runProvenanceFromEnv resolves run provenance from environment variables set by the caller
+// (e.g. the MCP server). Source defaults to "cli".
+func runProvenanceFromEnv() provenance {
+	source := os.Getenv(store.RunSourceEnv)
+	if source == "" {
+		source = store.RunSourceCLI
+	}
+	return provenance{
+		source:  source,
+		client:  os.Getenv(store.RunClientEnv),
+		session: os.Getenv(store.RunSessionEnv),
+	}
+}
+
+// recordRunStart writes an in-progress ("running") execution record before the run begins, so that
+// `flow logs` (from any process, via the shared store) can show the run as active. It is keyed by
+// the run's log archive ID so recordExecution can upsert it into its terminal state on completion.
+// No-op when there is no stable ID (legacy fallback: only the terminal record is written).
+// command/label are set for ad-hoc runs and empty for named executables.
+func recordRunStart(
+	ctx *context.Context, ref executable.Ref, startTime time.Time, prov provenance, command, label string,
+) {
+	if ctx.DataStore == nil || ctx.LogArchiveID == "" {
+		return
+	}
 	record := store.ExecutionRecord{
-		Ref:       ref.String(),
-		StartedAt: startTime,
-		Duration:  dur,
+		ID:         ctx.LogArchiveID,
+		Ref:        ref.String(),
+		StartedAt:  startTime,
+		Status:     store.RunRunning,
+		PID:        os.Getpid(),
+		Source:     prov.source,
+		ClientName: prov.client,
+		SessionID:  prov.session,
+		Command:    command,
+		Label:      label,
+	}
+	if recErr := ctx.DataStore.RecordExecution(record); recErr != nil {
+		logger.Log().Debug("failed to record run start", "err", recErr)
+	}
+}
+
+func recordExecution(
+	ctx *context.Context, ref executable.Ref, startTime time.Time, dur time.Duration, runErr error,
+	prov provenance, command, label string,
+) {
+	now := time.Now()
+	record := store.ExecutionRecord{
+		ID:          ctx.LogArchiveID,
+		Ref:         ref.String(),
+		StartedAt:   startTime,
+		CompletedAt: &now,
+		Duration:    dur,
+		Status:      store.RunCompleted,
+		PID:         os.Getpid(),
+		Source:      prov.source,
+		ClientName:  prov.client,
+		SessionID:   prov.session,
+		Command:     command,
+		Label:       label,
 	}
 	if runErr != nil {
 		record.ExitCode = 1
 		record.Error = runErr.Error()
+		record.Status = store.RunFailed
 	}
 	if archivePath := findArchiveByID(ctx.LogArchiveID); archivePath != "" {
 		record.LogArchiveID = archivePath

--- a/cmd/internal/flags/types.go
+++ b/cmd/internal/flags/types.go
@@ -286,6 +286,54 @@ var RunningFlag = &Metadata{
 	Required: false,
 }
 
+var CmdFlag = &Metadata{
+	Name: "cmd",
+	Usage: "Run an ad-hoc shell command through flow instead of a named executable. " +
+		"The command runs with the current workspace's environment and is recorded in `flow logs`. " +
+		"Repeat --cmd to run multiple commands in one invocation (see --mode).",
+	Default:  []string{},
+	Required: false,
+}
+
+var CmdModeFlag = &Metadata{
+	Name:     "mode",
+	Usage:    "How to run multiple --cmd commands: 'serial' (default) or 'parallel'.",
+	Default:  "serial",
+	Required: false,
+}
+
+var RunWorkspaceFlag = &Metadata{
+	Name: "workspace",
+	Usage: "Workspace whose environment the ad-hoc/transient run should use (only with --cmd or --spec). " +
+		"Defaults to the workspace containing the run directory, then the current workspace. " +
+		"Does not change the global current workspace.",
+	Default:  "",
+	Required: false,
+}
+
+var LabelFlag = &Metadata{
+	Name:     "label",
+	Usage:    "A short, human-readable label for an ad-hoc command (used in history). Only valid with --cmd.",
+	Default:  "",
+	Required: false,
+}
+
+var CmdDirFlag = &Metadata{
+	Name:     "dir",
+	Usage:    "Working directory for an ad-hoc command (defaults to the current directory). Only valid with --cmd.",
+	Default:  "",
+	Required: false,
+}
+
+var SpecFlag = &Metadata{
+	Name: "spec",
+	Usage: "Run a transient executable from an inline definition (any type: exec, serial, parallel, request, " +
+		"render, launch). Accepts inline YAML/JSON, '@path' to read a file, or '-' to read stdin. " +
+		"The executable is not saved to disk but is recorded in `flow logs`.",
+	Default:  "",
+	Required: false,
+}
+
 var ParameterValueFlag = &Metadata{
 	Name:      "param",
 	Shorthand: "p",

--- a/cmd/internal/flags/types.go
+++ b/cmd/internal/flags/types.go
@@ -208,7 +208,28 @@ var LogFilterWorkspaceFlag = &Metadata{
 
 var LogFilterStatusFlag = &Metadata{
 	Name:     "status",
-	Usage:    "Filter history by status (success or failure).",
+	Usage:    "Filter history by status (running, completed, or failed; success/failure accepted as aliases).",
+	Default:  "",
+	Required: false,
+}
+
+var LogFilterSourceFlag = &Metadata{
+	Name:     "source",
+	Usage:    "Filter history by run origin: 'cli' or 'mcp'.",
+	Default:  "",
+	Required: false,
+}
+
+var LogFilterSessionFlag = &Metadata{
+	Name:     "session",
+	Usage:    "Filter history to a single provenance session ID (e.g. an AI agent session).",
+	Default:  "",
+	Required: false,
+}
+
+var LogFilterClientFlag = &Metadata{
+	Name:     "client",
+	Usage:    "Filter history by the client that launched the run (e.g. 'claude', 'cursor').",
 	Default:  "",
 	Required: false,
 }

--- a/cmd/internal/logs.go
+++ b/cmd/internal/logs.go
@@ -42,6 +42,9 @@ func RegisterLogsCmd(ctx *context.Context, rootCmd *cobra.Command) {
 	RegisterFlag(ctx, subCmd, *flags.OutputFormatFlag)
 	RegisterFlag(ctx, subCmd, *flags.LogFilterWorkspaceFlag)
 	RegisterFlag(ctx, subCmd, *flags.LogFilterStatusFlag)
+	RegisterFlag(ctx, subCmd, *flags.LogFilterSourceFlag)
+	RegisterFlag(ctx, subCmd, *flags.LogFilterSessionFlag)
+	RegisterFlag(ctx, subCmd, *flags.LogFilterClientFlag)
 	RegisterFlag(ctx, subCmd, *flags.LogFilterSinceFlag)
 	RegisterFlag(ctx, subCmd, *flags.LogFilterLimitFlag)
 
@@ -151,6 +154,9 @@ func buildRecordFilter(cmd *cobra.Command) logs.RecordFilter {
 
 	f.Workspace = flags.ValueFor[string](cmd, *flags.LogFilterWorkspaceFlag, false)
 	f.Status = strings.ToLower(flags.ValueFor[string](cmd, *flags.LogFilterStatusFlag, false))
+	f.Source = strings.ToLower(flags.ValueFor[string](cmd, *flags.LogFilterSourceFlag, false))
+	f.Session = flags.ValueFor[string](cmd, *flags.LogFilterSessionFlag, false)
+	f.Client = flags.ValueFor[string](cmd, *flags.LogFilterClientFlag, false)
 	f.Limit = flags.ValueFor[int](cmd, *flags.LogFilterLimitFlag, false)
 
 	sinceStr := flags.ValueFor[string](cmd, *flags.LogFilterSinceFlag, false)
@@ -369,7 +375,10 @@ func logsAttachFunc(ctx *context.Context, runID string) {
 const logsExamples = `
   flow logs                          # all history
   flow logs --last                   # most recent entry with full output
-  flow logs --status failed   # only failed runs
+  flow logs --status failed          # only failed runs
+  flow logs --status running         # only in-progress runs
+  flow logs --source mcp             # only runs launched by an AI/MCP client
+  flow logs --session <id>           # everything one agent session ran
   flow logs run build                # history for 'run build' executable
   flow logs --running                # list active background processes
 `

--- a/cmd/internal/logs.go
+++ b/cmd/internal/logs.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/flowexec/flow/v2/cmd/internal/flags"
 	"github.com/flowexec/flow/v2/internal/io/logs"
+	"github.com/flowexec/flow/v2/internal/utils/process"
 	"github.com/flowexec/flow/v2/pkg/context"
 	"github.com/flowexec/flow/v2/pkg/filesystem"
 	"github.com/flowexec/flow/v2/pkg/logger"
@@ -241,7 +242,7 @@ func logsRunningFunc(ctx *context.Context, cmd *cobra.Command) {
 		if run.Status != store.BackgroundRunning {
 			continue
 		}
-		if !isProcessAlive(run.PID) {
+		if !process.Alive(run.PID) {
 			now := time.Now()
 			run.Status = store.BackgroundFailed
 			run.Error = "process exited unexpectedly"
@@ -343,7 +344,7 @@ func logsAttachFunc(ctx *context.Context, runID string) {
 		}
 
 		// No new data — check if the process is still alive.
-		if !isProcessAlive(run.PID) {
+		if !process.Alive(run.PID) {
 			// Final drain.
 			for {
 				n, _ = f.ReadAt(buf, pos)

--- a/cmd/internal/signal_unix.go
+++ b/cmd/internal/signal_unix.go
@@ -15,12 +15,3 @@ func terminateProcess(proc *os.Process) error {
 func notifyTermSignals(ch chan<- os.Signal) {
 	signal.Notify(ch, syscall.SIGINT, syscall.SIGTERM)
 }
-
-func isProcessAlive(pid int) bool {
-	proc, err := os.FindProcess(pid)
-	if err != nil {
-		return false
-	}
-	// On Unix, signal 0 checks for process existence without actually sending a signal.
-	return proc.Signal(syscall.Signal(0)) == nil
-}

--- a/cmd/internal/signal_windows.go
+++ b/cmd/internal/signal_windows.go
@@ -5,7 +5,6 @@ package internal
 import (
 	"os"
 	"os/signal"
-	"syscall"
 )
 
 func terminateProcess(proc *os.Process) error {
@@ -14,14 +13,4 @@ func terminateProcess(proc *os.Process) error {
 
 func notifyTermSignals(ch chan<- os.Signal) {
 	signal.Notify(ch, os.Interrupt)
-}
-
-func isProcessAlive(pid int) bool {
-	const processQueryLimitedInformation = 0x1000
-	handle, err := syscall.OpenProcess(processQueryLimitedInformation, false, uint32(pid))
-	if err != nil {
-		return false
-	}
-	_ = syscall.CloseHandle(handle)
-	return true
 }

--- a/docs/cli/flow_exec.md
+++ b/docs/cli/flow_exec.md
@@ -47,9 +47,15 @@ flow exec EXECUTABLE_ID [-- args...] [flags]
 
 ```
   -b, --background          Run the executable in the background and return a run ID immediately.
+      --cmd flow logs       Run an ad-hoc shell command through flow instead of a named executable. The command runs with the current workspace's environment and is recorded in flow logs. Repeat --cmd to run multiple commands in one invocation (see --mode).
+      --dir string          Working directory for an ad-hoc command (defaults to the current directory). Only valid with --cmd.
   -h, --help                help for exec
+      --label string        A short, human-readable label for an ad-hoc command (used in history). Only valid with --cmd.
   -m, --log-mode string     Log mode (text, logfmt, json, hidden)
+      --mode string         How to run multiple --cmd commands: 'serial' (default) or 'parallel'. (default "serial")
   -p, --param stringArray   Set a parameter value by env key. (i.e. KEY=value) Use multiple times to set multiple parameters. This will override any existing parameter values defined for the executable.
+      --spec flow logs      Run a transient executable from an inline definition (any type: exec, serial, parallel, request, render, launch). Accepts inline YAML/JSON, '@path' to read a file, or '-' to read stdin. The executable is not saved to disk but is recorded in flow logs.
+      --workspace string    Workspace whose environment the ad-hoc/transient run should use (only with --cmd or --spec). Defaults to the workspace containing the run directory, then the current workspace. Does not change the global current workspace.
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli/flow_logs.md
+++ b/docs/cli/flow_logs.md
@@ -16,7 +16,10 @@ flow logs [ref] [flags]
 
   flow logs                          # all history
   flow logs --last                   # most recent entry with full output
-  flow logs --status failed   # only failed runs
+  flow logs --status failed          # only failed runs
+  flow logs --status running         # only in-progress runs
+  flow logs --source mcp             # only runs launched by an AI/MCP client
+  flow logs --session <id>           # everything one agent session ran
   flow logs run build                # history for 'run build' executable
   flow logs --running                # list active background processes
 
@@ -25,13 +28,16 @@ flow logs [ref] [flags]
 ### Options
 
 ```
+      --client string      Filter history by the client that launched the run (e.g. 'claude', 'cursor').
   -h, --help               help for logs
       --last               Print the last execution's logs
       --limit int          Maximum number of records to display.
   -o, --output string      Output format. One of: yaml, json, or tui.
       --running            Show only active background processes.
+      --session string     Filter history to a single provenance session ID (e.g. an AI agent session).
       --since string       Filter history to entries after a duration (e.g. 1h, 30m, 7d).
-      --status string      Filter history by status (success or failure).
+      --source string      Filter history by run origin: 'cli' or 'mcp'.
+      --status string      Filter history by status (running, completed, or failed; success/failure accepted as aliases).
   -w, --workspace string   Filter history by workspace name.
 ```
 

--- a/docs/guides/ai-tools.md
+++ b/docs/guides/ai-tools.md
@@ -6,6 +6,8 @@ title: AI Tools
 
 flow exposes your automation to AI coding tools through the [Model Context Protocol](https://modelcontextprotocol.io). Your assistant can discover, run, and write executables the same way you do — with full access to workspace context, secrets handling, and execution history.
 
+Beyond your named executables, flow can also act as your assistant's **shell**: it wraps arbitrary commands as transient, self-documenting runs so everything the assistant does executes with the right environment and lands in a single, attributable history — instead of scattered, untracked shell calls.
+
 ## MCP Server
 
 ### Setup
@@ -37,10 +39,14 @@ The server runs over stdio. That's the entire setup.
 | `switch_workspace` | Change the active workspace |
 | `list_executables` | Browse executables — filterable by tag, verb, workspace |
 | `get_executable` | Full definition and metadata for a specific executable |
-| `execute` | Run an executable by ref |
-| `get_execution_logs` | Output from recent runs |
+| `execute` | Run a **named** executable by ref |
+| `run_command` | Run one or more **arbitrary** shell commands through flow (with a `label`, working `dir`, and optional `workspace`) — captured in history like any executable |
+| `run_executable` | Run a **transient executable of any type** from an inline `spec` — a serial/parallel batch, an HTTP `request`, a `render`, or a `launch` — without saving a file |
+| `get_execution_logs` | Output from recent runs, filterable by `source`/`session`/`status`, or `mine` for this session's own runs |
 | `sync_executables` | Refresh cached workspace and executable state |
 | `write_flowfile` | Create or update a `.flow` file, validated before writing |
+
+The three run tools form a ladder, closest-fit first: **`execute`** for a task you've already named, **`run_command`** for a one-off shell command, **`run_executable`** for something richer than a single command. Reaching for flow before a raw shell tool means every run inherits the workspace's environment and secrets and is recorded — see [Observability](#observability) below.
 
 **Prompts**
 
@@ -65,22 +71,50 @@ Create `.claude/skills/flow-context/SKILL.md`:
 ```markdown
 ---
 name: flow-context
-description: This project uses flow for automation. When asked to build, test, run, deploy, lint, or perform any dev task, check for a flow executable before falling back to raw shell commands.
+description: This project uses flow for automation. When asked to build, test, run, deploy, lint, generate, or perform any dev task — or to run any one-off shell command — prefer the flow MCP tools over raw Bash so the work runs with workspace env/secrets and is recorded in flow's history.
 user-invocable: false
 ---
 
-This repository uses flow for automation. The `mcp__flow__*` MCP tools are available.
+This repository uses flow for automation. The `mcp__flow__*` MCP tools are available —
+prefer them over raw Bash for anything runnable.
 
-When the user asks to build, test, deploy, lint, generate, or run anything:
+## Running work — pick the closest tool
 
-1. Call `mcp__flow__list_executables` first — check whether a flow executable already handles the task
-2. If found, use `mcp__flow__execute` with the matching verb and name
-3. Only fall back to shell if no flow executable exists for the task
+1. **Named task?** (build, test, lint, deploy, …) → `mcp__flow__list_executables` to find it,
+   then `mcp__flow__execute` with its verb + name. Don't hand-roll a shell command a flow
+   executable already covers.
+2. **Arbitrary one-off command?** (a `git ...`, a script) → `mcp__flow__run_command` with the
+   command and a short `label`. Runs with workspace env/secrets and lands in `flow logs`.
+   Pass `commands` (array) + `mode` (`serial`/`parallel`) to run several in one call.
+3. **Something richer than one command?** (a serial/parallel batch, an HTTP `request`) →
+   `mcp__flow__run_executable` with an inline `spec`.
+4. Only fall back to Bash for things that genuinely shouldn't be recorded or that flow isn't
+   suited to (e.g. interactive/TTY programs).
 
-Call `mcp__flow__get_info` at the start of a session or when you need schema URLs to author .flow files.
+Call `mcp__flow__get_info` at the start of a session, or when you need schema URLs to author
+.flow files. To review what you've run this session, call `mcp__flow__get_execution_logs`
+with `mine: true`.
 ```
 
 `user-invocable: false` keeps it out of the `/` command menu — it's not something you invoke, it's just always there. Update the body with the specific executables your project uses.
+
+## Observability
+
+Every run flow launches — whether a named `execute`, a `run_command`, or a `run_executable` — is recorded as one lifecycle-aware history entry: written as `running` when it starts and updated to `completed` or `failed` when it finishes. Runs launched over MCP also capture **provenance**: which tool called (`claude`, `cursor`, …) and its session ID. That turns flow's history into an audit trail of what your assistant did.
+
+Query it from the CLI:
+
+```shell
+flow logs                              # everything, most recent first
+flow logs --status running             # what's in flight right now
+flow logs --source mcp                 # only runs launched by an AI client
+flow logs --session <id>               # everything one agent session ran
+flow logs --client cursor --status failed
+```
+
+The interactive `flow logs` view shows an **Origin** column (the client, or `cli`/`mcp`) so you can see at a glance which runs came from an assistant; opening a record reveals its full source, client, and session.
+
+The assistant can review its own activity too: `get_execution_logs` accepts the same `source`/`session`/`status` filters, plus `mine: true` — a shortcut that scopes results to the calling session's own runs, so it can check "what have I run so far?" without guessing a session ID.
 
 ## llms.txt
 

--- a/docs/guides/execution-history.md
+++ b/docs/guides/execution-history.md
@@ -14,7 +14,9 @@ Open the interactive log viewer:
 flow logs
 ```
 
-This shows a table of recent executions with the executable reference, time, duration, and status. Press `Enter` to view full details and log output for any entry.
+This shows a table of recent executions with the executable reference, time, duration, status, and origin (which client launched the run). Press `Enter` to view full details and log output for any entry.
+
+Each record is **lifecycle-aware**: it appears as `running` the moment a run starts and updates to `completed` or `failed` when it finishes — so an in-progress foreground run is visible from another terminal, not just after it exits. (A run whose process dies unexpectedly is reconciled to `failed` the next time you view history.)
 
 **TUI keyboard shortcuts:**
 
@@ -57,13 +59,29 @@ Use flags to narrow results:
 
 ```shell
 flow logs -w my-workspace            # filter by workspace
-flow logs --status failure            # only failed executions
+flow logs --status failed             # running, completed, or failed
+flow logs --status running            # only in-progress runs
 flow logs --since 1h                  # last hour (supports d, h, m, s)
 flow logs --limit 5                   # at most 5 records
-flow logs -w api --status success --since 7d
+flow logs -w api --status completed --since 7d
 ```
 
+`--status` accepts the lifecycle values `running`, `completed`, and `failed` (`success`/`failure` still work as aliases).
+
 Filters work with all output modes (`--last`, `-o yaml`, TUI, etc.).
+
+### By Origin (Provenance)
+
+Every run records **where it came from**: `cli` for a run you started, or `mcp` for one launched by an AI assistant through the [MCP server](ai-tools.md) — along with the client name and session ID for MCP runs. This turns history into an audit trail of what an assistant did on your behalf.
+
+```shell
+flow logs --source mcp               # only runs launched by an AI client
+flow logs --session <id>             # everything one agent session ran
+flow logs --client cursor            # runs launched by a specific client
+flow logs --source mcp --status failed
+```
+
+An assistant connected over MCP can review its own runs the same way — see [AI Tools → Observability](ai-tools.md#observability).
 
 ## Background Execution
 

--- a/docs/guides/integrations.md
+++ b/docs/guides/integrations.md
@@ -35,14 +35,16 @@ The server uses stdio transport and provides AI assistants with:
 
 **Available Tools:**
 - `get_info` - Get flow information, schemas, and current context
-- `execute` - Execute flow workflows
+- `execute` - Run a named executable by ref
+- `run_command` - Run arbitrary shell command(s) through flow, captured in history
+- `run_executable` - Run a transient executable of any type from an inline spec
 - `list_workspaces` - List all registered workspaces
 - `get_workspace` - Get details about a specific workspace
 - `get_workspace_config` - Get the full configuration for a specific workspace
 - `switch_workspace` - Change the current workspace
 - `list_executables` - List and filter executables across workspaces
 - `get_executable` - Get detailed information about an executable
-- `get_execution_logs` - Retrieve recent execution logs
+- `get_execution_logs` - Retrieve recent execution logs, with provenance filters
 - `sync_executables` - Sync workspace and executable state
 - `write_flowfile` - Create or update a flow file in a workspace
 

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -18,7 +18,7 @@ Flow organizes automation into **workspaces** (projects/domains), each rooted at
 - [Executables](https://flowexec.io/guides/executables): Full reference for executable types (exec, serial, parallel, request, launch, render)
 - [Workspaces](https://flowexec.io/guides/workspaces): How workspaces organize projects and domains
 - [Secrets](https://flowexec.io/guides/secrets): Vault-backed secret storage and injection into executions
-- [Execution History & Logs](https://flowexec.io/guides/execution-history): Viewing, attaching to, and inspecting past runs
+- [Execution History & Logs](https://flowexec.io/guides/execution-history): Viewing, attaching to, and inspecting past runs, including live run status and provenance (which client/session launched a run)
 
 ## Advanced
 
@@ -27,7 +27,7 @@ Flow organizes automation into **workspaces** (projects/domains), each rooted at
 - [Advanced Workflows](https://flowexec.io/guides/advanced): Serial/parallel pipelines, retries, conditional execution, arguments/params
 - [Interactive UI](https://flowexec.io/guides/interactive): TUI customization and keybindings
 - [Integrations](https://flowexec.io/guides/integrations): MCP server, GitHub Actions, Docker, CI pipelines
-- [AI Tools](https://flowexec.io/guides/ai-tools): MCP setup, llms.txt, JSON schemas, Claude Code skills and settings
+- [AI Tools](https://flowexec.io/guides/ai-tools): MCP setup and tools (including running arbitrary commands through flow), execution observability/provenance, llms.txt, JSON schemas, Claude Code skills and settings
 
 ## Configuration Reference
 
@@ -54,7 +54,7 @@ Flow organizes automation into **workspaces** (projects/domains), each rooted at
 
 ### Logs
 
-- [flow logs](https://flowexec.io/cli/flow_logs): View execution history
+- [flow logs](https://flowexec.io/cli/flow_logs): View execution history, filterable by status/workspace/source/session/client
 - [flow logs attach](https://flowexec.io/cli/flow_logs_attach): Attach to a running background execution
 - [flow logs clear](https://flowexec.io/cli/flow_logs_clear): Clear log history
 - [flow logs kill](https://flowexec.io/cli/flow_logs_kill): Terminate a background execution

--- a/internal/io/logs/output.go
+++ b/internal/io/logs/output.go
@@ -13,12 +13,18 @@ import (
 )
 
 type recordOutput struct {
-	Ref       string `json:"ref"               yaml:"ref"`
-	StartedAt string `json:"startedAt"         yaml:"startedAt"`
-	Duration  string `json:"duration"          yaml:"duration"`
-	ExitCode  int    `json:"exitCode"          yaml:"exitCode"`
-	Error     string `json:"error,omitempty"   yaml:"error,omitempty"`
-	LogFile   string `json:"logFile,omitempty" yaml:"logFile,omitempty"`
+	Ref        string `json:"ref"                  yaml:"ref"`
+	StartedAt  string `json:"startedAt"            yaml:"startedAt"`
+	Duration   string `json:"duration"             yaml:"duration"`
+	Status     string `json:"status"               yaml:"status"`
+	ExitCode   int    `json:"exitCode"             yaml:"exitCode"`
+	Error      string `json:"error,omitempty"      yaml:"error,omitempty"`
+	LogFile    string `json:"logFile,omitempty"    yaml:"logFile,omitempty"`
+	Command    string `json:"command,omitempty"    yaml:"command,omitempty"`
+	Label      string `json:"label,omitempty"      yaml:"label,omitempty"`
+	Source     string `json:"source,omitempty"     yaml:"source,omitempty"`
+	ClientName string `json:"clientName,omitempty" yaml:"clientName,omitempty"`
+	SessionID  string `json:"sessionId,omitempty"  yaml:"sessionId,omitempty"`
 }
 
 type recordsResponse struct {
@@ -27,11 +33,17 @@ type recordsResponse struct {
 
 func toRecordOutput(r UnifiedRecord) recordOutput {
 	out := recordOutput{
-		Ref:       r.Ref,
-		StartedAt: r.StartedAt.Format(time.RFC3339),
-		Duration:  r.Duration.Round(time.Millisecond).String(),
-		ExitCode:  r.ExitCode,
-		Error:     r.Error,
+		Ref:        r.Ref,
+		StartedAt:  r.StartedAt.Format(time.RFC3339),
+		Duration:   r.Duration.Round(time.Millisecond).String(),
+		Status:     string(CanonicalStatus(r)),
+		ExitCode:   r.ExitCode,
+		Error:      r.Error,
+		Command:    r.Command,
+		Label:      r.Label,
+		Source:     r.Source,
+		ClientName: r.ClientName,
+		SessionID:  r.SessionID,
 	}
 	if r.LogEntry != nil {
 		out.LogFile = r.LogEntry.Path
@@ -70,16 +82,12 @@ func PrintRecords(format string, records []UnifiedRecord) {
 
 func printRecordsText(records []UnifiedRecord) {
 	for _, r := range records {
-		status := "ok"
-		if r.ExitCode != 0 {
-			status = fmt.Sprintf("exit(%d)", r.ExitCode)
-		}
 		logger.Log().Println(fmt.Sprintf(
 			"%s  %-40s  %6s  %s",
 			r.StartedAt.Format(time.RFC3339),
 			r.Ref,
 			r.Duration.Round(time.Millisecond),
-			status,
+			StatusText(r),
 		))
 	}
 }
@@ -102,15 +110,25 @@ func PrintLastRecord(format string, record UnifiedRecord, stdout io.Writer) {
 		}
 		_, _ = fmt.Fprint(stdout, string(data))
 	default:
-		status := "ok"
-		if record.ExitCode != 0 {
-			status = fmt.Sprintf("exit(%d)", record.ExitCode)
-		}
-
 		_, _ = fmt.Fprintf(stdout, "Executable: %s\n", record.Ref)
+		if record.Label != "" {
+			_, _ = fmt.Fprintf(stdout, "Label:      %s\n", record.Label)
+		}
+		if record.Command != "" {
+			_, _ = fmt.Fprintf(stdout, "Command:    %s\n", record.Command)
+		}
 		_, _ = fmt.Fprintf(stdout, "Time:       %s\n", record.StartedAt.Format(time.RFC3339))
 		_, _ = fmt.Fprintf(stdout, "Duration:   %s\n", record.Duration.Round(time.Millisecond))
-		_, _ = fmt.Fprintf(stdout, "Status:     %s\n", status)
+		_, _ = fmt.Fprintf(stdout, "Status:     %s\n", StatusText(record))
+		if record.Source != "" {
+			_, _ = fmt.Fprintf(stdout, "Source:     %s\n", record.Source)
+		}
+		if record.ClientName != "" {
+			_, _ = fmt.Fprintf(stdout, "Client:     %s\n", record.ClientName)
+		}
+		if record.SessionID != "" {
+			_, _ = fmt.Fprintf(stdout, "Session:    %s\n", record.SessionID)
+		}
 		if record.Error != "" {
 			_, _ = fmt.Fprintf(stdout, "Error:      %s\n", record.Error)
 		}

--- a/internal/io/logs/output.go
+++ b/internal/io/logs/output.go
@@ -83,11 +83,12 @@ func PrintRecords(format string, records []UnifiedRecord) {
 func printRecordsText(records []UnifiedRecord) {
 	for _, r := range records {
 		logger.Log().Println(fmt.Sprintf(
-			"%s  %-40s  %6s  %s",
+			"%s  %-40s  %6s  %-10s  %s",
 			r.StartedAt.Format(time.RFC3339),
 			r.Ref,
 			r.Duration.Round(time.Millisecond),
 			StatusText(r),
+			OriginText(r),
 		))
 	}
 }

--- a/internal/io/logs/records.go
+++ b/internal/io/logs/records.go
@@ -1,12 +1,14 @@
 package logs
 
 import (
+	"fmt"
 	"sort"
 	"strings"
 	"time"
 
 	tuikitIO "github.com/flowexec/tuikit/io"
 
+	"github.com/flowexec/flow/v2/internal/utils/process"
 	"github.com/flowexec/flow/v2/pkg/store"
 )
 
@@ -71,6 +73,53 @@ type UnifiedRecord struct {
 	LogEntry *tuikitIO.ArchiveEntry
 }
 
+// CanonicalStatus returns the lifecycle status of a record (running/completed/failed), deriving it
+// from the exit code for legacy records that predate the Status field.
+func CanonicalStatus(r UnifiedRecord) store.RunStatus {
+	if r.Status != "" {
+		return r.Status
+	}
+	if r.ExitCode == 0 {
+		return store.RunCompleted
+	}
+	return store.RunFailed
+}
+
+// StatusText returns a human-readable status for display: "running" for in-progress runs,
+// otherwise "ok" or "exit(N)" derived from the exit code.
+func StatusText(r UnifiedRecord) string {
+	if CanonicalStatus(r) == store.RunRunning {
+		return "running"
+	}
+	if r.ExitCode == 0 {
+		return "ok"
+	}
+	return fmt.Sprintf("exit(%d)", r.ExitCode)
+}
+
+// reconcileStale marks any "running" record whose process is no longer alive as failed, persisting
+// the correction back to the store. This prevents an abnormally-terminated run from lingering as
+// active, mirroring the stale-detection done for background runs in `flow logs --running`.
+func reconcileStale(ds store.DataStore, records []store.ExecutionRecord) []store.ExecutionRecord {
+	for i := range records {
+		r := &records[i]
+		if r.Status != store.RunRunning || r.PID == 0 || process.Alive(r.PID) {
+			continue
+		}
+		now := time.Now()
+		r.Status = store.RunFailed
+		r.ExitCode = 1
+		r.CompletedAt = &now
+		if r.Error == "" {
+			r.Error = "process exited unexpectedly"
+		}
+		if ds != nil && r.ID != "" {
+			_ = ds.RecordExecution(*r)
+		}
+	}
+	return records
+}
+
 // LoadRecords retrieves all execution history from the data store, joined with any matching log archive entries.
 // If ds is nil, returns empty (log-only fallback is not supported without metadata).
 func LoadRecords(ds store.DataStore, logsDir string) ([]UnifiedRecord, error) {
@@ -82,6 +131,7 @@ func LoadRecords(ds store.DataStore, logsDir string) ([]UnifiedRecord, error) {
 	if err != nil {
 		return nil, err
 	}
+	records = reconcileStale(ds, records)
 
 	archiveIndex := buildArchiveIndex(logsDir)
 	return joinRecords(records, archiveIndex), nil
@@ -97,6 +147,7 @@ func LoadRecordsForRef(ds store.DataStore, logsDir string, ref string, limit int
 	if err != nil {
 		return nil, err
 	}
+	records = reconcileStale(ds, records)
 
 	archiveIndex := buildArchiveIndex(logsDir)
 	return joinRecords(records, archiveIndex), nil

--- a/internal/io/logs/records.go
+++ b/internal/io/logs/records.go
@@ -15,9 +15,28 @@ import (
 // RecordFilter holds optional criteria for filtering unified records.
 type RecordFilter struct {
 	Workspace string
-	Status    string // "success" or "failure"
+	Status    string // lifecycle status: running/completed/failed (success/failure accepted as aliases)
+	Source    string // provenance origin: "cli" or "mcp"
+	Session   string // provenance session ID
+	Client    string // provenance client name (e.g. "claude", "cursor")
 	Since     time.Time
 	Limit     int
+}
+
+// matchStatus reports whether a record's lifecycle status matches the requested filter value,
+// accepting friendly aliases (success/failure) alongside the canonical running/completed/failed.
+func matchStatus(r UnifiedRecord, want string) bool {
+	canonical := CanonicalStatus(r)
+	switch strings.ToLower(strings.TrimSpace(want)) {
+	case "success", "completed", "complete", "ok":
+		return canonical == store.RunCompleted
+	case "failure", "failed", "error":
+		return canonical == store.RunFailed
+	case "running", "active", "in-progress":
+		return canonical == store.RunRunning
+	default:
+		return string(canonical) == strings.ToLower(strings.TrimSpace(want))
+	}
 }
 
 // extractWorkspace parses the workspace from a ref formatted as "verb ws/ns:name".
@@ -44,17 +63,17 @@ func FilterRecords(records []UnifiedRecord, f RecordFilter) []UnifiedRecord {
 				continue
 			}
 		}
-		if f.Status != "" {
-			switch f.Status {
-			case "success":
-				if r.ExitCode != 0 {
-					continue
-				}
-			case "failure":
-				if r.ExitCode == 0 {
-					continue
-				}
-			}
+		if f.Status != "" && !matchStatus(r, f.Status) {
+			continue
+		}
+		if f.Source != "" && !strings.EqualFold(r.Source, f.Source) {
+			continue
+		}
+		if f.Session != "" && r.SessionID != f.Session {
+			continue
+		}
+		if f.Client != "" && !strings.EqualFold(r.ClientName, f.Client) {
+			continue
 		}
 		if !f.Since.IsZero() && r.StartedAt.Before(f.Since) {
 			continue
@@ -95,6 +114,19 @@ func StatusText(r UnifiedRecord) string {
 		return "ok"
 	}
 	return fmt.Sprintf("exit(%d)", r.ExitCode)
+}
+
+// OriginText returns a compact label identifying who launched a run for at-a-glance display:
+// the client name when known (e.g. "claude"), otherwise the source ("cli"/"mcp"), or "-" for
+// legacy records that predate provenance capture.
+func OriginText(r UnifiedRecord) string {
+	if r.ClientName != "" {
+		return r.ClientName
+	}
+	if r.Source != "" {
+		return r.Source
+	}
+	return "-"
 }
 
 // reconcileStale marks any "running" record whose process is no longer alive as failed, persisting

--- a/internal/io/logs/records_test.go
+++ b/internal/io/logs/records_test.go
@@ -201,6 +201,50 @@ func TestLoadRecords_SkipsRefsThatErrorDuringHistoryLookup(t *testing.T) {
 	}
 }
 
+func TestStatusText(t *testing.T) {
+	running := logs.UnifiedRecord{ExecutionRecord: store.ExecutionRecord{Status: store.RunRunning}}
+	if got := logs.StatusText(running); got != "running" {
+		t.Fatalf("expected 'running', got %q", got)
+	}
+	// Legacy records (no Status) derive from exit code.
+	if got := logs.StatusText(rec("x", 0, time.Now())); got != "ok" {
+		t.Fatalf("expected 'ok', got %q", got)
+	}
+	if got := logs.StatusText(rec("x", 2, time.Now())); got != "exit(2)" {
+		t.Fatalf("expected 'exit(2)', got %q", got)
+	}
+}
+
+func TestLoadRecords_ReconcilesStaleRunningRecord(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	ds := storeMocks.NewMockDataStore(ctrl)
+	now := time.Now()
+
+	// A "running" record whose process is no longer alive (an implausibly high PID).
+	ds.EXPECT().ListExecutionRefs().Return([]string{"one"}, nil)
+	ds.EXPECT().GetExecutionHistory("one", 10).Return([]store.ExecutionRecord{
+		{ID: "run-1", Ref: "one", StartedAt: now, Status: store.RunRunning, PID: 2_000_000_000},
+	}, nil)
+	// The stale record is persisted back as failed.
+	ds.EXPECT().RecordExecution(gomock.Any()).DoAndReturn(func(r store.ExecutionRecord) error {
+		if r.Status != store.RunFailed {
+			t.Fatalf("expected stale record persisted as failed, got %q", r.Status)
+		}
+		return nil
+	})
+
+	got, err := logs.LoadRecords(ds, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 record, got %d", len(got))
+	}
+	if logs.StatusText(got[0]) == "running" {
+		t.Fatalf("expected stale record to no longer render as running")
+	}
+}
+
 func TestLoadRecordsForRef_UsesGivenRefAndLimit(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	ds := storeMocks.NewMockDataStore(ctrl)

--- a/internal/io/logs/records_test.go
+++ b/internal/io/logs/records_test.go
@@ -17,6 +17,16 @@ func rec(ref string, exit int, at time.Time) logs.UnifiedRecord {
 	return logs.UnifiedRecord{ExecutionRecord: store.ExecutionRecord{Ref: ref, ExitCode: exit, StartedAt: at}}
 }
 
+func provRec(ref, source, client, session string) logs.UnifiedRecord {
+	return logs.UnifiedRecord{ExecutionRecord: store.ExecutionRecord{
+		Ref:        ref,
+		StartedAt:  time.Now(),
+		Source:     source,
+		ClientName: client,
+		SessionID:  session,
+	}}
+}
+
 func TestFilterRecords_EmptyFilterReturnsAll(t *testing.T) {
 	now := time.Now()
 	records := []logs.UnifiedRecord{
@@ -59,6 +69,67 @@ func TestFilterRecords_Status(t *testing.T) {
 	failures := logs.FilterRecords(records, logs.RecordFilter{Status: "failure"})
 	if len(failures) != 1 {
 		t.Fatalf("expected 1 failure record, got %d", len(failures))
+	}
+}
+
+func TestFilterRecords_StatusLifecycle(t *testing.T) {
+	now := time.Now()
+	running := logs.UnifiedRecord{ExecutionRecord: store.ExecutionRecord{
+		Ref: "exec a/ns:live", Status: store.RunRunning, StartedAt: now,
+	}}
+	completed := rec("exec a/ns:done", 0, now) // canonical "completed"
+	failed := rec("exec a/ns:bad", 1, now)     // canonical "failed"
+	records := []logs.UnifiedRecord{running, completed, failed}
+
+	cases := map[string]string{
+		"running":   "exec a/ns:live",
+		"completed": "exec a/ns:done",
+		"success":   "exec a/ns:done", // alias
+		"failed":    "exec a/ns:bad",
+		"failure":   "exec a/ns:bad", // alias
+	}
+	for status, wantRef := range cases {
+		got := logs.FilterRecords(records, logs.RecordFilter{Status: status})
+		if len(got) != 1 {
+			t.Fatalf("status %q: expected 1 record, got %d", status, len(got))
+		}
+		if got[0].Ref != wantRef {
+			t.Fatalf("status %q: expected %q, got %q", status, wantRef, got[0].Ref)
+		}
+	}
+
+	// A running record must NOT be counted as a success (exit code is still zero).
+	if got := logs.FilterRecords(records, logs.RecordFilter{Status: "success"}); len(got) != 1 {
+		t.Fatalf("expected 'success' to exclude the running record, got %d", len(got))
+	}
+}
+
+func TestFilterRecords_Provenance(t *testing.T) {
+	records := []logs.UnifiedRecord{
+		provRec("exec a/ns:1", "mcp", "claude", "sess-1"),
+		provRec("exec a/ns:2", "mcp", "cursor", "sess-2"),
+		provRec("exec a/ns:3", "cli", "", ""),
+	}
+
+	if got := logs.FilterRecords(records, logs.RecordFilter{Source: "mcp"}); len(got) != 2 {
+		t.Fatalf("expected 2 mcp records, got %d", len(got))
+	}
+	// Source matching is case-insensitive.
+	if got := logs.FilterRecords(records, logs.RecordFilter{Source: "MCP"}); len(got) != 2 {
+		t.Fatalf("expected case-insensitive source match, got %d", len(got))
+	}
+	if got := logs.FilterRecords(records, logs.RecordFilter{Session: "sess-2"}); len(got) != 1 {
+		t.Fatalf("expected 1 record for session sess-2, got %d", len(got))
+	} else if got[0].Ref != "exec a/ns:2" {
+		t.Fatalf("unexpected record for session filter: %q", got[0].Ref)
+	}
+	if got := logs.FilterRecords(records, logs.RecordFilter{Client: "claude"}); len(got) != 1 {
+		t.Fatalf("expected 1 claude record, got %d", len(got))
+	}
+	// Session + source combine (AND).
+	got := logs.FilterRecords(records, logs.RecordFilter{Source: "mcp", Session: "sess-1"})
+	if len(got) != 1 || got[0].Ref != "exec a/ns:1" {
+		t.Fatalf("expected the mcp/sess-1 record only, got %+v", got)
 	}
 }
 

--- a/internal/io/logs/views.go
+++ b/internal/io/logs/views.go
@@ -33,10 +33,11 @@ func NewUnifiedLogView(
 
 func unifiedListView(container *tuikit.Container, records []UnifiedRecord, ds store.DataStore) tuikit.View {
 	columns := []views.TableColumn{
-		{Title: fmt.Sprintf("History (%d)", len(records)), Percentage: 35},
-		{Title: "Time", Percentage: 25},
-		{Title: "Duration", Percentage: 20},
-		{Title: "Status", Percentage: 20},
+		{Title: fmt.Sprintf("History (%d)", len(records)), Percentage: 30},
+		{Title: "Time", Percentage: 22},
+		{Title: "Duration", Percentage: 16},
+		{Title: "Status", Percentage: 16},
+		{Title: "Origin", Percentage: 16},
 	}
 	rows := make([]views.TableRow, 0, len(records))
 	for i, r := range records {
@@ -46,6 +47,7 @@ func unifiedListView(container *tuikit.Container, records []UnifiedRecord, ds st
 				r.StartedAt.Format(time.RFC3339),
 				r.Duration.Round(time.Millisecond).String(),
 				StatusText(r),
+				OriginText(r),
 				fmt.Sprintf("%d", i),
 			},
 		})
@@ -54,11 +56,11 @@ func unifiedListView(container *tuikit.Container, records []UnifiedRecord, ds st
 	table := views.NewTable(container.RenderState(), columns, rows, views.TableDisplayMini)
 	table.SetOnSelect(func(_ int) error {
 		row := table.GetSelectedRow()
-		if row == nil || len(row.Data()) < 5 {
+		if row == nil || len(row.Data()) < 6 {
 			return fmt.Errorf("no record selected")
 		}
 		var idx int
-		if _, err := fmt.Sscanf(row.Data()[4], "%d", &idx); err != nil || idx >= len(records) {
+		if _, err := fmt.Sscanf(row.Data()[5], "%d", &idx); err != nil || idx >= len(records) {
 			return fmt.Errorf("invalid record")
 		}
 		return container.SetView(unifiedDetailView(container, records[idx], ds))

--- a/internal/io/logs/views.go
+++ b/internal/io/logs/views.go
@@ -31,13 +31,6 @@ func NewUnifiedLogView(
 	return unifiedListView(container, records, ds)
 }
 
-func statusText(exitCode int) string {
-	if exitCode == 0 {
-		return "ok"
-	}
-	return fmt.Sprintf("exit(%d)", exitCode)
-}
-
 func unifiedListView(container *tuikit.Container, records []UnifiedRecord, ds store.DataStore) tuikit.View {
 	columns := []views.TableColumn{
 		{Title: fmt.Sprintf("History (%d)", len(records)), Percentage: 35},
@@ -52,7 +45,7 @@ func unifiedListView(container *tuikit.Container, records []UnifiedRecord, ds st
 				r.Ref,
 				r.StartedAt.Format(time.RFC3339),
 				r.Duration.Round(time.Millisecond).String(),
-				statusText(r.ExitCode),
+				StatusText(r),
 				fmt.Sprintf("%d", i),
 			},
 		})
@@ -112,9 +105,26 @@ func unifiedDetailView(container *tuikit.Container, record UnifiedRecord, ds sto
 
 	metadata := []views.DetailField{
 		{Key: "Executable", Value: record.Ref},
-		{Key: "Time", Value: record.StartedAt.Format(time.RFC3339)},
-		{Key: "Duration", Value: record.Duration.Round(time.Millisecond).String()},
-		{Key: "Status", Value: statusText(record.ExitCode)},
+	}
+	if record.Label != "" {
+		metadata = append(metadata, views.DetailField{Key: "Label", Value: record.Label})
+	}
+	if record.Command != "" {
+		metadata = append(metadata, views.DetailField{Key: "Command", Value: record.Command})
+	}
+	metadata = append(metadata,
+		views.DetailField{Key: "Time", Value: record.StartedAt.Format(time.RFC3339)},
+		views.DetailField{Key: "Duration", Value: record.Duration.Round(time.Millisecond).String()},
+		views.DetailField{Key: "Status", Value: StatusText(record)},
+	)
+	if record.Source != "" {
+		metadata = append(metadata, views.DetailField{Key: "Source", Value: record.Source})
+	}
+	if record.ClientName != "" {
+		metadata = append(metadata, views.DetailField{Key: "Client", Value: record.ClientName})
+	}
+	if record.SessionID != "" {
+		metadata = append(metadata, views.DetailField{Key: "Session", Value: record.SessionID})
 	}
 	if record.Error != "" {
 		metadata = append(metadata, views.DetailField{Key: "Error", Value: record.Error})

--- a/internal/mcp/command_executor.go
+++ b/internal/mcp/command_executor.go
@@ -2,13 +2,50 @@ package mcp
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"os/exec"
 
+	"github.com/mark3labs/mcp-go/server"
 	"github.com/pkg/errors"
+
+	"github.com/flowexec/flow/v2/pkg/store"
 )
 
 const cliBinaryEnvKey = "FLOW_CLI_BINARY"
+
+// provenanceCtxKey keys the run provenance carried on a context into the flow subprocess env.
+type provenanceCtxKey struct{}
+
+// runProvenance identifies who/what is launching a run, propagated to the flow subprocess as env vars.
+type runProvenance struct {
+	Source  string
+	Client  string
+	Session string
+}
+
+// withProvenance returns a context carrying run provenance for ExecuteContext to forward as env vars.
+func withProvenance(ctx context.Context, p runProvenance) context.Context {
+	return context.WithValue(ctx, provenanceCtxKey{}, p)
+}
+
+func provenanceFromContext(ctx context.Context) (runProvenance, bool) {
+	p, ok := ctx.Value(provenanceCtxKey{}).(runProvenance)
+	return p, ok
+}
+
+// mcpProvenance builds run provenance for an MCP-originated command, capturing the calling client's
+// name and session ID from the MCP session (when the transport exposes them).
+func mcpProvenance(ctx context.Context) runProvenance {
+	prov := runProvenance{Source: store.RunSourceMCP}
+	if sess := server.ClientSessionFromContext(ctx); sess != nil {
+		prov.Session = sess.SessionID()
+		if withInfo, ok := sess.(server.SessionWithClientInfo); ok {
+			prov.Client = withInfo.GetClientInfo().Name
+		}
+	}
+	return prov
+}
 
 //go:generate mockgen -destination=mocks/command_executor.go -package=mocks . CommandExecutor
 type CommandExecutor interface {
@@ -34,6 +71,13 @@ func (c *FlowCLIExecutor) ExecuteContext(ctx context.Context, args ...string) (s
 		name = envName
 	}
 	cmd := exec.CommandContext(ctx, name, args...) // #nosec G204,G702
+	if p, ok := provenanceFromContext(ctx); ok {
+		cmd.Env = append(os.Environ(),
+			fmt.Sprintf("%s=%s", store.RunSourceEnv, p.Source),
+			fmt.Sprintf("%s=%s", store.RunClientEnv, p.Client),
+			fmt.Sprintf("%s=%s", store.RunSessionEnv, p.Session),
+		)
+	}
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		// Only return an error if it's not an exit error.

--- a/internal/mcp/output_types.go
+++ b/internal/mcp/output_types.go
@@ -98,12 +98,18 @@ type ExecutionOutput struct {
 
 // LogEntry represents a single execution log record.
 type LogEntry struct {
-	Ref       string `json:"ref"`
-	StartedAt string `json:"startedAt"`
-	Duration  string `json:"duration"`
-	ExitCode  int    `json:"exitCode"`
-	Error     string `json:"error,omitempty"`
-	LogFile   string `json:"logFile,omitempty"`
+	Ref        string `json:"ref"`
+	StartedAt  string `json:"startedAt"`
+	Duration   string `json:"duration"`
+	Status     string `json:"status,omitempty"`
+	ExitCode   int    `json:"exitCode"`
+	Error      string `json:"error,omitempty"`
+	LogFile    string `json:"logFile,omitempty"`
+	Command    string `json:"command,omitempty"`
+	Label      string `json:"label,omitempty"`
+	Source     string `json:"source,omitempty"`
+	ClientName string `json:"clientName,omitempty"`
+	SessionID  string `json:"sessionId,omitempty"`
 }
 
 // LogListOutput is the output of the get_execution_logs tool.

--- a/internal/mcp/resources/server-instructions.md
+++ b/internal/mcp/resources/server-instructions.md
@@ -16,6 +16,8 @@ Prefer running work **through flow** over a raw shell tool — you get the works
 
 `run_command` and `run_executable` take an optional `workspace` to scope a run to another workspace's environment **without** changing the current workspace; otherwise the workspace is inferred from the run directory, then the current one.
 
+Every run you launch is attributed to this session. `get_execution_logs` with `mine: true` returns only what *this* session has run — use it to review your own recent work; `source`/`session`/`status` filter more broadly.
+
 ## Notes
 
 - `execute` runs a defined executable, not a raw command — use `run_command` for arbitrary commands. If the executable defines `args`, pass them in `args`; if it defines prompt `params`, pass them in `params` as an EnvKey→value map.

--- a/internal/mcp/resources/server-instructions.md
+++ b/internal/mcp/resources/server-instructions.md
@@ -1,81 +1,23 @@
 # Flow MCP Server Instructions
 
-You are connected to a Flow CLI automation platform via MCP. Flow is a versatile local automation platform that helps 
-users organize and execute ANY type of workflow through declarative YAML configuration - 
-from development/operations tasks to personal productivity tools, content management, and custom integrations.
+Flow is a local automation platform. **Executables** (tasks of any kind) are declared in `*.flow` YAML files; **workspaces** group them by project and are rooted at a `flow.yaml`. Secrets live in **vaults**. Templates (`*.flow.tmpl`) generate new workflows.
 
-## Essential Context to Load First
+## Start here
 
-Unless this information is provided to you, always start new conversations by calling the `get_info` tool.
-The response is intentionally lightweight and includes:
-- Current workspace, namespace, and vault context
-- A short platform summary
-- URLs for the docs site, the `llms.txt` docs index, JSON schemas, and key guide pages
+Call `get_info` once at the start of a session (unless the context is already provided). It returns the current workspace/namespace/vault, a short summary, and URLs for docs (`llmsTxtUrl`), JSON schemas (`schemaUrls.*`), and guides (`guideUrls.*`). Fetch those URLs when you need deeper detail instead of asking the user. `write_flowfile` validates against the flowfile schema server-side, so you don't need the schema in context to author files — fetch `schemaUrls.flowFile` only as the authoritative reference for non-trivial executables.
 
-You should only need to run this at the start of the conversation as the response is unlikely to change unless you or the user
-explicitly switches context or configurations.
+## Flow as your shell
 
-### When you need deeper context
+Prefer running work **through flow** over a raw shell tool — you get the workspace's environment and secrets, captured logs, and a durable, attributable history entry (visible via `get_execution_logs` / `flow logs`) instead of an untracked shell command.
 
-Fetch documentation from the URLs that `get_info` returns rather than asking the user:
-- **`llmsTxtUrl`** (`https://flowexec.io/llms.txt`) — index of all docs pages in the llmstxt.org format
-- **`schemaUrls.*`** — JSON schemas for flowfile, workspace, template, and config files; use these when generating or validating YAML
-- **`guideUrls.*`** — specific guide pages for concepts, file types, workspaces, secrets, templates, and the first-workflow tutorial
+- `execute` — run a **named** executable (build, test, lint, deploy, …) by verb + optional ID. Try this first; discover names with `list_executables`.
+- `run_command` — run an **arbitrary** shell command when no named executable fits (a one-off `git status`, `npm ci`, a script). Pass a short `label` so the history entry is self-documenting; `dir` sets the working directory. To run several commands in one call, pass `commands` (array) with `mode: serial` (default) or `parallel`.
+- `run_executable` — run a **transient executable of any type** from an inline `spec` when a single command isn't enough: a `serial`/`parallel` batch, an HTTP `request`, a `render`, or a `launch`. The `spec` is one executable definition (same shape as an entry under a flowfile's `executables:`); author non-trivial ones against `schemaUrls.flowFile`.
 
-The `write_flowfile` tool already validates YAML against the flowfile schema server-side, so you don't need to embed the schema in the client context to generate valid files — but fetching the schema from `schemaUrls.flowFile` is the authoritative reference when authoring non-trivial executables.
+`run_command` and `run_executable` take an optional `workspace` to scope a run to another workspace's environment **without** changing the current workspace; otherwise the workspace is inferred from the run directory, then the current one.
 
-## Flow Concepts
+## Notes
 
-If the user prompts with any of these concepts, then they are likely referring to the flow automation platform.
-
-- Executables (the building blocks): these are automated tasks for ANY purpose. 
-  - These are defined in flow files (with the *.flow or *.flow.yaml extensions)
-- Workspaces (project organization): organize executables by project, domain, or purpose (e.g. `web-dev`, `personal-automation`, `content-management`, `home-lab`
-    - The configuration for these are defined at the root of the project in a `flow.yaml` file
-
-## Best Practices
-
-### Safety
-- **Always confirm** before running `execute` with potentially destructive commands
-- **Validate YAML** before suggesting users save it to files. JSON schema URLs are returned by `get_info` under `schemaUrls`, and `write_flowfile` performs server-side validation on write.
-- **Check current context** before making workspace assumptions
-- **Use appropriate filters** when using tools that may return long lists. For instance, provide the appropriate arguments for the `list_executables` tool if you know the target workspace, a keyword, or verb for the executable that you're looking for.
-
-### Helpful Guidance
-- **Explain file types** when users seem confused about flow.yaml vs .flow files
-- **Suggest appropriate verbs** based on what users want to accomplish. The name and namespaces are optional but should be used if it would provide meaningful context.
-- **Recommend workspace organization** for different domains (dev, personal, content, etc.). Try to follow existing project patterns; flow files can be defined anywhere in a workspace.
-- **Show executable reference formats** when users ask about running tasks
-- **Think creatively** about automation opportunities - if they mention repetitive tasks, suggest flow solutions
-- **Encourage experimentation** - Flow's `request` type is perfect for API integrations, `launch` for opening files/apps, the secret vault for injecting secrets into executions, etc.
-
-### Common Patterns
-- **List → Detail → Execute**: Help users discover, understand, then run executables
-- **Validate → Fix → Validate**: Help users create correct YAML configurations
-- **Context → Recommend**: Use current workspace/namespace to suggest relevant actions
-
-## Response Style
-
-### JSON Tool Responses
-When tools return JSON, present it in a user-friendly way:
-- **Summarize key information** instead of dumping raw JSON; using details from the descriptions if available.
-- **Highlight important details** like dependencies or required vault secrets.
-- **Format long lists** in readable bullet points or tables
-- **Explain next steps** users might want to take
-- **Provide useful suggestion** when you notice opportunities for utilizing more of flow's robust features to simplify configurations
-
-### Error Handling
-- **Interpret error messages** from Flow CLI and explain in plain language
-- **Suggest fixes** for common configuration mistakes
-- **Guide users** through validation and correction process
-
-### Educational Approach
-- **Teach Flow concepts** while helping with immediate tasks
-- **Show examples** of executable configurations for various use cases
-- **Inspire creativity** - help users see automation opportunities they might not have considered
-
-## Tool Usage Gotchas
-- `execute` can be used to run flow executables, not arbitrary shell commands or non-exec flow commands.
-  - If an executable has `args` defined, you must provide them in the `args` field of the `execute` tool.
-  - If an executable has `params` defined where the type is `prompt`, you must provide them in the `params` field of the `execute` tool. Do this by providing a mapping of the EnvKey to the value you want to provide.
-- When running tools, be aware that the current workspace may the output / response. Switch to the workspace that you expect if it's not already set in the context.
+- `execute` runs a defined executable, not a raw command — use `run_command` for arbitrary commands. If the executable defines `args`, pass them in `args`; if it defines prompt `params`, pass them in `params` as an EnvKey→value map.
+- Confirm before running anything destructive.
+- The current workspace affects results. Filter `list_executables` (workspace/verb/keyword/tag) rather than listing everything. Prefer summarizing tool JSON over dumping it raw.

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -396,6 +396,20 @@ var _ = Describe("MCP Server", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(getTextContent(result)).To(Equal(expectedOutput))
 			})
+
+			It("should forward source/session/status filters to the CLI", func() {
+				mockExecutor.EXPECT().
+					Execute("logs", "--output", "json", "--source", "mcp", "--session", "sess-1", "--status", "running").
+					Return(`{"history":[]}`, nil)
+
+				_, err := mcpClient.CallTool(ctx, newCallToolRequest("get_execution_logs", map[string]interface{}{
+					"source":  "mcp",
+					"session": "sess-1",
+					"status":  "running",
+				}))
+
+				Expect(err).ToNot(HaveOccurred())
+			})
 		})
 
 		Context("sync_executables tool", func() {

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -89,6 +89,8 @@ var _ = Describe("MCP Server", func() {
 				"get_executable",
 				"list_executables",
 				"execute",
+				"run_command",
+				"run_executable",
 				"get_execution_logs",
 				"sync_executables",
 				"write_flowfile",
@@ -100,19 +102,17 @@ var _ = Describe("MCP Server", func() {
 			}
 		})
 
-		It("should include output schema on list tools", func() {
+		It("should include output schema on the execution tools", func() {
 			toolsResult, err := mcpClient.ListTools(ctx, mcp.ListToolsRequest{})
 			Expect(err).ToNot(HaveOccurred())
 
-			// Verify tools that should have output schemas
+			// Output schemas are advertised only on the execution tools (small, high-value). The
+			// read/list tools omit them to keep the always-loaded tool surface small — they still
+			// return structuredContent at call time.
 			toolsWithSchema := map[string]bool{
-				"list_workspaces":      true,
-				"list_executables":     true,
-				"get_workspace":        true,
-				"get_execution_logs":   true,
-				"get_info":             true,
-				"write_flowfile":       true,
-				"get_workspace_config": true,
+				"execute":        true,
+				"run_command":    true,
+				"run_executable": true,
 			}
 
 			for _, tool := range toolsResult.Tools {
@@ -319,6 +319,66 @@ var _ = Describe("MCP Server", func() {
 
 				Expect(err).ToNot(HaveOccurred())
 				Expect(getTextContent(result)).To(ContainSubstring("execution result with no args"))
+			})
+		})
+
+		Context("run_command tool", func() {
+			It("should run an ad-hoc command via flow exec --cmd with label and dir", func() {
+				mockExecutor.EXPECT().
+					ExecuteContext(gomock.Any(), "exec", "--cmd", "echo hi", "--label", "greet", "--dir", "/tmp").
+					Return("command result", nil)
+
+				result, err := mcpClient.CallTool(ctx, newCallToolRequest("run_command", map[string]interface{}{
+					"command": "echo hi",
+					"label":   "greet",
+					"dir":     "/tmp",
+				}))
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(getTextContent(result)).To(ContainSubstring("command result"))
+			})
+
+			It("should run multiple commands in one call with a mode", func() {
+				mockExecutor.EXPECT().
+					ExecuteContext(gomock.Any(), "exec", "--cmd", "echo a", "--cmd", "echo b", "--mode", "parallel").
+					Return("batch result", nil)
+
+				result, err := mcpClient.CallTool(ctx, newCallToolRequest("run_command", map[string]interface{}{
+					"commands": []interface{}{"echo a", "echo b"},
+					"mode":     "parallel",
+				}))
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(getTextContent(result)).To(ContainSubstring("batch result"))
+			})
+
+			It("should require a command or commands", func() {
+				result, err := mcpClient.CallTool(ctx, newCallToolRequest("run_command", map[string]interface{}{}))
+				Expect(err).ToNot(HaveOccurred())
+				Expect(result.IsError).To(BeTrue())
+			})
+		})
+
+		Context("run_executable tool", func() {
+			It("should run a transient executable from an inline spec", func() {
+				spec := `{"verb":"run","serial":{"execs":[{"cmd":"echo one"}]}}`
+				mockExecutor.EXPECT().
+					ExecuteContext(gomock.Any(), "exec", "--spec", spec, "--label", "batch").
+					Return("spec result", nil)
+
+				result, err := mcpClient.CallTool(ctx, newCallToolRequest("run_executable", map[string]interface{}{
+					"spec":  spec,
+					"label": "batch",
+				}))
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(getTextContent(result)).To(ContainSubstring("spec result"))
+			})
+
+			It("should require a spec", func() {
+				result, err := mcpClient.CallTool(ctx, newCallToolRequest("run_executable", map[string]interface{}{}))
+				Expect(err).ToNot(HaveOccurred())
+				Expect(result.IsError).To(BeTrue())
 			})
 		})
 

--- a/internal/mcp/tools_executable.go
+++ b/internal/mcp/tools_executable.go
@@ -24,12 +24,11 @@ func addExecutableTools(srv *server.MCPServer, executor CommandExecutor) {
 			"what parameters it accepts, and what secrets it requires. "+
 			"Use before executing an unfamiliar executable or when debugging a failure."),
 		mcp.WithString("executable_verb", mcp.Required(),
-			mcp.Enum(executable.SortedValidVerbs()...),
-			mcp.Description("Executable verb")),
+			mcp.Description("Executable verb (e.g. run, exec, build, test, deploy). "+
+				"Validated server-side; see the flow docs for the full verb list.")),
 		mcp.WithString("executable_id",
 			mcp.Pattern(`^([a-zA-Z0-9_-]+(/[a-zA-Z0-9_-]+)?:)?[a-zA-Z0-9_-]+$`),
 			mcp.Description("Executable ID (workspace/namespace:name or just name if using the current workspace/namespace)")),
-		mcp.WithOutputSchema[ExecutableOutput](),
 	)
 	getExecutable.Annotations = mcp.ToolAnnotation{
 		Title:           "Get a specific executable by reference",
@@ -48,7 +47,6 @@ func addExecutableTools(srv *server.MCPServer, executor CommandExecutor) {
 		mcp.WithString("keyword", mcp.Description("Keyword filter (optional)")),
 		mcp.WithString("tag", mcp.Description("Tag filter (optional)")),
 		mcp.WithString("cursor", mcp.Description("Pagination cursor for next page of results")),
-		mcp.WithOutputSchema[ExecutableListOutput](),
 	)
 	listExecutables.Annotations = mcp.ToolAnnotation{
 		Title:           "List executables",
@@ -62,8 +60,8 @@ func addExecutableTools(srv *server.MCPServer, executor CommandExecutor) {
 			"for build, test, deploy, lint, generate, and other dev tasks — flow handles environment setup, "+
 			"secret injection, retries, and logging automatically."),
 		mcp.WithString("executable_verb", mcp.Required(),
-			mcp.Enum(executable.SortedValidVerbs()...),
-			mcp.Description("Executable verb")),
+			mcp.Description("Executable verb (e.g. run, exec, build, test, deploy). "+
+				"Validated server-side; see the flow docs for the full verb list.")),
 		mcp.WithString("executable_id",
 			mcp.Pattern(`^([a-zA-Z0-9_-]+(/[a-zA-Z0-9_-]+)?:)?[a-zA-Z0-9_-]+$`),
 			mcp.Description(
@@ -81,6 +79,9 @@ func addExecutableTools(srv *server.MCPServer, executor CommandExecutor) {
 	}
 	srv.AddTool(executeFlow, executeFlowHandler(srv, executor))
 
+	addRunCommandTool(srv, executor)
+	addRunExecutableTool(srv, executor)
+
 	writeFlowfile := mcp.NewTool("write_flowfile",
 		mcp.WithDescription("Create or update a .flow workflow file. Use when the user wants to add or modify "+
 			"automation — builds, tests, deploys, scripts. Validates the YAML against the schema before "+
@@ -91,7 +92,6 @@ func addExecutableTools(srv *server.MCPServer, executor CommandExecutor) {
 			mcp.Description("Full YAML content of the flowfile")),
 		mcp.WithBoolean("overwrite",
 			mcp.Description("Whether to overwrite an existing file (default: false)")),
-		mcp.WithOutputSchema[WriteFlowFileOutput](),
 	)
 	writeFlowfile.Annotations = mcp.ToolAnnotation{
 		Title:           "Write a flow file",
@@ -167,7 +167,7 @@ func listExecutablesHandler(executor CommandExecutor) server.ToolHandlerFunc {
 			TotalCount:  totalCount,
 		}
 		jsonData, _ := json.Marshal(result)
-		return mcp.NewToolResultText(string(jsonData)), nil
+		return mcp.NewToolResultStructured(result, string(jsonData)), nil
 	}
 }
 
@@ -197,6 +197,9 @@ func executeFlowHandler(srv *server.MCPServer, executor CommandExecutor) server.
 			cmdArgs = append(cmdArgs, "--sync")
 		}
 
+		// Capture the MCP caller's identity so the resulting execution record records who ran it.
+		ctx = withProvenance(ctx, mcpProvenance(ctx))
+
 		sendProgress(srv, ctx, progressToken, 0, 2, "Preparing execution")
 		output, err := executor.ExecuteContext(ctx, cmdArgs...)
 
@@ -215,8 +218,155 @@ func executeFlowHandler(srv *server.MCPServer, executor CommandExecutor) server.
 
 		result := ExecutionOutput{Output: output}
 		jsonData, _ := json.Marshal(result)
-		return mcp.NewToolResultText(string(jsonData)), nil
+		return mcp.NewToolResultStructured(result, string(jsonData)), nil
 	}
+}
+
+func addRunCommandTool(srv *server.MCPServer, executor CommandExecutor) {
+	runCommand := mcp.NewTool("run_command",
+		mcp.WithDescription("Run one or more shell commands through flow instead of a raw shell tool. Commands run "+
+			"with the current workspace's environment and secrets, output is captured to flow's logs, and each run "+
+			"is recorded in execution history with provenance (visible via get_execution_logs / `flow logs`). "+
+			"Prefer this for build, test, run, and one-off commands so the work is observable and reproducible. "+
+			"Pass `commands` (with `mode`) to run several commands in a single call."),
+		mcp.WithString("command",
+			mcp.Description("A single shell command to run. Provide this or `commands`.")),
+		mcp.WithArray("commands", mcp.WithStringItems(),
+			mcp.Description("Multiple shell commands to run in one call (as a serial or parallel batch — see `mode`). "+
+				"Provide this or `command`.")),
+		mcp.WithString("mode",
+			mcp.Description("How to run `commands`: 'serial' (default, stop on first failure) or 'parallel'.")),
+		mcp.WithString("label",
+			mcp.Description("Short human-readable label describing what the command(s) do (recorded in history).")),
+		mcp.WithString("dir",
+			mcp.Description("Working directory for the command (defaults to the current directory).")),
+		mcp.WithString("workspace",
+			mcp.Description("Workspace whose environment to use for this run. Defaults to the workspace containing "+
+				"the working directory, then the current workspace. Does not change the global current workspace.")),
+		mcp.WithBoolean("sync", mcp.Description("Sync flow cache and workspaces before running.")),
+		mcp.WithOutputSchema[ExecutionOutput](),
+	)
+	runCommand.Annotations = mcp.ToolAnnotation{
+		Title:        "Run ad-hoc shell command(s) through flow",
+		ReadOnlyHint: boolPtr(false), DestructiveHint: boolPtr(true),
+		IdempotentHint: boolPtr(false), OpenWorldHint: boolPtr(true),
+	}
+	srv.AddTool(runCommand, runCommandHandler(srv, executor))
+}
+
+func runCommandHandler(srv *server.MCPServer, executor CommandExecutor) server.ToolHandlerFunc {
+	return func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		var commands []string
+		if c := request.GetString("command", ""); c != "" {
+			commands = append(commands, c)
+		}
+		commands = append(commands, request.GetStringSlice("commands", nil)...)
+		if len(commands) == 0 {
+			return toolError(ErrCodeInvalidInput, "command or commands is required"), nil
+		}
+
+		cmdArgs := []string{"exec"}
+		for _, c := range commands {
+			cmdArgs = append(cmdArgs, "--cmd", c)
+		}
+		if mode := request.GetString("mode", ""); mode != "" {
+			cmdArgs = append(cmdArgs, "--mode", mode)
+		}
+		if label := request.GetString("label", ""); label != "" {
+			cmdArgs = append(cmdArgs, "--label", label)
+		}
+		if dir := request.GetString("dir", ""); dir != "" {
+			cmdArgs = append(cmdArgs, "--dir", dir)
+		}
+		if ws := request.GetString("workspace", ""); ws != "" {
+			cmdArgs = append(cmdArgs, "--workspace", ws)
+		}
+		if request.GetBool("sync", false) {
+			cmdArgs = append(cmdArgs, "--sync")
+		}
+
+		return runTransientTool(ctx, srv, request, executor, cmdArgs, "command failed")
+	}
+}
+
+func addRunExecutableTool(srv *server.MCPServer, executor CommandExecutor) {
+	runExecutable := mcp.NewTool("run_executable",
+		mcp.WithDescription("Run a transient executable of ANY type from an inline definition, without saving a "+
+			".flow file. Use this when a single command (run_command) isn't enough — e.g. a `serial`/`parallel` "+
+			"batch of steps, an HTTP `request`, or a `render`/`launch`. The spec is the same shape as one entry "+
+			"under a flowfile's `executables:` list. Runs with workspace env/secrets and is recorded in history. "+
+			"Author non-trivial specs against the flowfile schema (see get_info schemaUrls.flowFile)."),
+		mcp.WithString("spec", mcp.Required(),
+			mcp.Description("A single executable definition as YAML or JSON (e.g. {\"verb\":\"run\",\"serial\":"+
+				"{\"execs\":[{\"cmd\":\"...\"},{\"cmd\":\"...\"}]}}).")),
+		mcp.WithString("label",
+			mcp.Description("Short human-readable label recorded in history (defaults to the executable's name).")),
+		mcp.WithString("workspace",
+			mcp.Description("Workspace whose environment to use for this run. Defaults to the workspace containing "+
+				"the working directory, then the current workspace. Does not change the global current workspace.")),
+		mcp.WithBoolean("sync", mcp.Description("Sync flow cache and workspaces before running.")),
+		mcp.WithOutputSchema[ExecutionOutput](),
+	)
+	runExecutable.Annotations = mcp.ToolAnnotation{
+		Title:        "Run a transient executable of any type",
+		ReadOnlyHint: boolPtr(false), DestructiveHint: boolPtr(true),
+		IdempotentHint: boolPtr(false), OpenWorldHint: boolPtr(true),
+	}
+	srv.AddTool(runExecutable, runExecutableHandler(srv, executor))
+}
+
+func runExecutableHandler(srv *server.MCPServer, executor CommandExecutor) server.ToolHandlerFunc {
+	return func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		spec, err := request.RequireString("spec")
+		if err != nil {
+			return toolError(ErrCodeInvalidInput, "spec is required"), nil
+		}
+		cmdArgs := []string{"exec", "--spec", spec}
+		if label := request.GetString("label", ""); label != "" {
+			cmdArgs = append(cmdArgs, "--label", label)
+		}
+		if ws := request.GetString("workspace", ""); ws != "" {
+			cmdArgs = append(cmdArgs, "--workspace", ws)
+		}
+		if request.GetBool("sync", false) {
+			cmdArgs = append(cmdArgs, "--sync")
+		}
+		return runTransientTool(ctx, srv, request, executor, cmdArgs, "executable failed")
+	}
+}
+
+// runTransientTool shells out to `flow exec` for the transient run tools (run_command, run_executable),
+// tagging the run with MCP provenance and returning a structured result.
+func runTransientTool(
+	ctx context.Context, srv *server.MCPServer, request mcp.CallToolRequest,
+	executor CommandExecutor, cmdArgs []string, failMsg string,
+) (*mcp.CallToolResult, error) {
+	var progressToken any
+	if request.Params.Meta != nil {
+		progressToken = request.Params.Meta.ProgressToken
+	}
+
+	// Tag the run as MCP-originated with the caller's identity.
+	ctx = withProvenance(ctx, mcpProvenance(ctx))
+
+	sendProgress(srv, ctx, progressToken, 0, 2, "Preparing execution")
+	output, err := executor.ExecuteContext(ctx, cmdArgs...)
+
+	if ctx.Err() != nil {
+		return toolError(ErrCodeCancelled, "execution was cancelled"), nil
+	}
+
+	sendProgress(srv, ctx, progressToken, 1, 2, "Processing result")
+
+	if err != nil {
+		return toolError(ErrCodeExecutionFailed, fmt.Sprintf("%s: %s", failMsg, output)), nil
+	}
+
+	sendProgress(srv, ctx, progressToken, 2, 2, "Complete")
+
+	result := ExecutionOutput{Output: output}
+	jsonData, _ := json.Marshal(result)
+	return mcp.NewToolResultStructured(result, string(jsonData)), nil
 }
 
 func writeFlowfileHandler(srv *server.MCPServer) server.ToolHandlerFunc {
@@ -272,7 +422,7 @@ func writeFlowfileHandler(srv *server.MCPServer) server.ToolHandlerFunc {
 			Overwritten: overwrite,
 		}
 		jsonData, _ := json.Marshal(output)
-		return mcp.NewToolResultText(string(jsonData)), nil
+		return mcp.NewToolResultStructured(output, string(jsonData)), nil
 	}
 }
 

--- a/internal/mcp/tools_system.go
+++ b/internal/mcp/tools_system.go
@@ -42,8 +42,14 @@ func addSystemTools(srv *server.MCPServer, executor CommandExecutor) {
 
 	getExecutionLogs := mcp.NewTool("get_execution_logs",
 		mcp.WithDescription("Retrieve output from recent flow executions. "+
-			"Use when debugging a failed run or when the user asks about the results of a previous task."),
+			"Use when debugging a failed run or when the user asks about the results of a previous task. "+
+			"Set `mine` to see only what this session has run so far."),
 		mcp.WithBoolean("last", mcp.Description("Get only the last execution logs")),
+		mcp.WithBoolean("mine", mcp.Description("Only return runs launched by this MCP session "+
+			"(useful for reviewing what you have run so far).")),
+		mcp.WithString("source", mcp.Description("Filter by run origin: 'cli' or 'mcp'.")),
+		mcp.WithString("session", mcp.Description("Filter to a single provenance session ID.")),
+		mcp.WithString("status", mcp.Description("Filter by status: running, completed, or failed.")),
 		mcp.WithString("cursor", mcp.Description("Pagination cursor for next page of results")),
 	)
 	getExecutionLogs.Annotations = mcp.ToolAnnotation{
@@ -56,7 +62,6 @@ func addSystemTools(srv *server.MCPServer, executor CommandExecutor) {
 	sync := mcp.NewTool("sync_executables",
 		mcp.WithDescription("Refresh the cached workspace and executable state. "+
 			"Use when executables seem out of date or after adding new .flow files."),
-		mcp.WithOutputSchema[SyncOutput](),
 	)
 	sync.Annotations = mcp.ToolAnnotation{
 		Title:           "Sync executable and workspace state",
@@ -118,13 +123,35 @@ func getInfoHandler(_ context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResu
 }
 
 func getExecutionLogsHandler(executor CommandExecutor) server.ToolHandlerFunc {
-	return func(_ context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	return func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		last := request.GetBool("last", false)
 		cursor := request.GetString("cursor", "")
+		source := request.GetString("source", "")
+		session := request.GetString("session", "")
+		status := request.GetString("status", "")
+
+		// `mine` scopes results to the calling MCP session's own runs so an agent can review
+		// exactly what it launched — resolved from the live session, not client-supplied.
+		if request.GetBool("mine", false) {
+			prov := mcpProvenance(ctx)
+			source = prov.Source
+			if prov.Session != "" {
+				session = prov.Session
+			}
+		}
 
 		cmdArgs := []string{"logs", "--output", "json"}
 		if last {
 			cmdArgs = append(cmdArgs, "--last")
+		}
+		if source != "" {
+			cmdArgs = append(cmdArgs, "--source", source)
+		}
+		if session != "" {
+			cmdArgs = append(cmdArgs, "--session", session)
+		}
+		if status != "" {
+			cmdArgs = append(cmdArgs, "--status", status)
 		}
 
 		output, err := executor.Execute(cmdArgs...)

--- a/internal/mcp/tools_system.go
+++ b/internal/mcp/tools_system.go
@@ -32,7 +32,6 @@ func addSystemTools(srv *server.MCPServer, executor CommandExecutor) {
 				"schema URLs for authoring .flow files, and the docs index (llms.txt). "+
 				"Call this at the start of a session to understand the project's automation setup, "+
 				"or whenever you need schema URLs to author or validate flow configuration."),
-		mcp.WithOutputSchema[FlowInfoOutput](),
 	)
 	getFlowInfo.Annotations = mcp.ToolAnnotation{
 		Title:           "Get flow information and current context",
@@ -46,7 +45,6 @@ func addSystemTools(srv *server.MCPServer, executor CommandExecutor) {
 			"Use when debugging a failed run or when the user asks about the results of a previous task."),
 		mcp.WithBoolean("last", mcp.Description("Get only the last execution logs")),
 		mcp.WithString("cursor", mcp.Description("Pagination cursor for next page of results")),
-		mcp.WithOutputSchema[LogListOutput](),
 	)
 	getExecutionLogs.Annotations = mcp.ToolAnnotation{
 		Title:           "Get execution logs",
@@ -116,7 +114,7 @@ func getInfoHandler(_ context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResu
 		return toolError(ErrCodeInternal, fmt.Sprintf("failed to marshal response: %s", err)), nil
 	}
 
-	return mcp.NewToolResultText(string(jsonData)), nil
+	return mcp.NewToolResultStructured(output, string(jsonData)), nil
 }
 
 func getExecutionLogsHandler(executor CommandExecutor) server.ToolHandlerFunc {
@@ -146,7 +144,7 @@ func getExecutionLogsHandler(executor CommandExecutor) server.ToolHandlerFunc {
 				TotalCount: 1,
 			}
 			jsonData, _ := json.Marshal(result)
-			return mcp.NewToolResultText(string(jsonData)), nil
+			return mcp.NewToolResultStructured(result, string(jsonData)), nil
 		}
 
 		// Parse the CLI list output and apply pagination.
@@ -168,7 +166,7 @@ func getExecutionLogsHandler(executor CommandExecutor) server.ToolHandlerFunc {
 			TotalCount: totalCount,
 		}
 		jsonData, _ := json.Marshal(result)
-		return mcp.NewToolResultText(string(jsonData)), nil
+		return mcp.NewToolResultStructured(result, string(jsonData)), nil
 	}
 }
 
@@ -195,6 +193,6 @@ func syncStateHandler(srv *server.MCPServer, executor CommandExecutor) server.To
 
 		result := SyncOutput{Output: output}
 		jsonData, _ := json.Marshal(result)
-		return mcp.NewToolResultText(string(jsonData)), nil
+		return mcp.NewToolResultStructured(result, string(jsonData)), nil
 	}
 }

--- a/internal/mcp/tools_workspace.go
+++ b/internal/mcp/tools_workspace.go
@@ -16,7 +16,6 @@ func addWorkspaceTools(srv *server.MCPServer, executor CommandExecutor) {
 	getWorkspace := mcp.NewTool("get_workspace",
 		mcp.WithString("workspace_name", mcp.Required(), mcp.Description("Registered workspace name")),
 		mcp.WithDescription("Get details about a registered flow workspaces"),
-		mcp.WithOutputSchema[WorkspaceOutput](),
 	)
 	getWorkspace.Annotations = mcp.ToolAnnotation{
 		Title:           "Get a specific workspace by name",
@@ -28,7 +27,6 @@ func addWorkspaceTools(srv *server.MCPServer, executor CommandExecutor) {
 	listWorkspaces := mcp.NewTool("list_workspaces",
 		mcp.WithDescription("List all registered flow workspaces"),
 		mcp.WithString("cursor", mcp.Description("Pagination cursor for next page of results")),
-		mcp.WithOutputSchema[WorkspaceListOutput](),
 	)
 	listWorkspaces.Annotations = mcp.ToolAnnotation{
 		Title:           "List workspaces",
@@ -52,7 +50,6 @@ func addWorkspaceTools(srv *server.MCPServer, executor CommandExecutor) {
 	getWorkspaceConfig := mcp.NewTool("get_workspace_config",
 		mcp.WithString("name", mcp.Required(), mcp.Description("Workspace name")),
 		mcp.WithDescription("Get the full workspace configuration as structured JSON"),
-		mcp.WithOutputSchema[WorkspaceConfigOutput](),
 	)
 	getWorkspaceConfig.Annotations = mcp.ToolAnnotation{
 		Title:           "Get workspace configuration",
@@ -81,7 +78,7 @@ func getWorkspaceHandler(executor CommandExecutor) server.ToolHandlerFunc {
 		}
 
 		jsonData, _ := json.Marshal(ws)
-		return mcp.NewToolResultText(string(jsonData)), nil
+		return mcp.NewToolResultStructured(ws, string(jsonData)), nil
 	}
 }
 
@@ -112,7 +109,7 @@ func listWorkspacesHandler(executor CommandExecutor) server.ToolHandlerFunc {
 			TotalCount: totalCount,
 		}
 		jsonData, _ := json.Marshal(result)
-		return mcp.NewToolResultText(string(jsonData)), nil
+		return mcp.NewToolResultStructured(result, string(jsonData)), nil
 	}
 }
 
@@ -132,7 +129,7 @@ func switchWorkspaceHandler(srv *server.MCPServer, executor CommandExecutor) ser
 
 		result := SwitchWorkspaceOutput{Output: output}
 		jsonData, _ := json.Marshal(result)
-		return mcp.NewToolResultText(string(jsonData)), nil
+		return mcp.NewToolResultStructured(result, string(jsonData)), nil
 	}
 }
 
@@ -176,6 +173,6 @@ func getWorkspaceConfigHandler() server.ToolHandlerFunc {
 		}
 
 		jsonData, _ := json.Marshal(output)
-		return mcp.NewToolResultText(string(jsonData)), nil
+		return mcp.NewToolResultStructured(output, string(jsonData)), nil
 	}
 }

--- a/internal/mcp/tools_workspace.go
+++ b/internal/mcp/tools_workspace.go
@@ -38,7 +38,6 @@ func addWorkspaceTools(srv *server.MCPServer, executor CommandExecutor) {
 	switchWorkspace := mcp.NewTool("switch_workspace",
 		mcp.WithString("workspace_name", mcp.Required(), mcp.Description("Registered workspace name")),
 		mcp.WithDescription("Change the current workspace"),
-		mcp.WithOutputSchema[SwitchWorkspaceOutput](),
 	)
 	switchWorkspace.Annotations = mcp.ToolAnnotation{
 		Title:           "Change the current workspace",

--- a/internal/utils/process/process_unix.go
+++ b/internal/utils/process/process_unix.go
@@ -1,0 +1,21 @@
+//go:build !windows
+
+package process
+
+import (
+	"os"
+	"syscall"
+)
+
+// Alive reports whether a process with the given PID is currently running.
+func Alive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	// On Unix, signal 0 checks for process existence without actually sending a signal.
+	return proc.Signal(syscall.Signal(0)) == nil
+}

--- a/internal/utils/process/process_windows.go
+++ b/internal/utils/process/process_windows.go
@@ -1,0 +1,19 @@
+//go:build windows
+
+package process
+
+import "syscall"
+
+// Alive reports whether a process with the given PID is currently running.
+func Alive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	const processQueryLimitedInformation = 0x1000
+	handle, err := syscall.OpenProcess(processQueryLimitedInformation, false, uint32(pid))
+	if err != nil {
+		return false
+	}
+	_ = syscall.CloseHandle(handle)
+	return true
+}

--- a/pkg/imports/imports_test.go
+++ b/pkg/imports/imports_test.go
@@ -43,7 +43,7 @@ var _ = Describe("ExecutablesFromImports", func() {
 
 		result, err := imports.ExecutablesFromImports("ws", ff)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(len(result)).To(BeNumerically(">", 0))
+		Expect(result).ToNot(BeEmpty())
 		for _, e := range result {
 			Expect(e.Exec).ToNot(BeNil())
 		}

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -26,6 +27,17 @@ const (
 	BucketEnv = "FLOW_PROCESS_BUCKET"
 	// RootBucket is the name of the global (root) process bucket.
 	RootBucket = "root"
+
+	// RunSourceEnv, RunClientEnv, and RunSessionEnv carry execution provenance into a run.
+	// They are set by callers (e.g. the MCP server) on the flow subprocess so the resulting
+	// execution record can record who/what launched it.
+	RunSourceEnv  = "FLOW_RUN_SOURCE"
+	RunClientEnv  = "FLOW_RUN_CLIENT"
+	RunSessionEnv = "FLOW_RUN_SESSION"
+
+	// RunSourceCLI and RunSourceMCP are the recognized values for RunSourceEnv / ExecutionRecord.Source.
+	RunSourceCLI = "cli"
+	RunSourceMCP = "mcp"
 
 	openTimeout = 3 * time.Second
 )
@@ -63,15 +75,45 @@ type DataStore interface { //nolint:interfacebloat // single backing store with 
 	Close() error
 }
 
+// RunStatus represents the lifecycle state of an execution record.
+type RunStatus string
+
+const (
+	RunRunning   RunStatus = "running"
+	RunCompleted RunStatus = "completed"
+	RunFailed    RunStatus = "failed"
+)
+
 // ExecutionRecord holds metadata about a single executable run.
+//
+// A record is written once at run start with Status=running, then upserted (by ID) into its
+// terminal state at completion. Records without an ID (e.g. legacy history) are appended rather
+// than upserted, so an in-progress row is never shown for them.
 type ExecutionRecord struct {
-	Ref       string        `json:"ref"`
-	StartedAt time.Time     `json:"startedAt"`
-	Duration  time.Duration `json:"duration"`
-	ExitCode  int           `json:"exitCode"`
-	Error     string        `json:"error,omitempty"`
+	// ID is a stable per-run identifier (the run's log archive UUID) used as the upsert key.
+	// Empty for legacy records, which fall back to append-only storage.
+	ID          string        `json:"id,omitempty"`
+	Ref         string        `json:"ref"`
+	StartedAt   time.Time     `json:"startedAt"`
+	CompletedAt *time.Time    `json:"completedAt,omitempty"`
+	Duration    time.Duration `json:"duration"`
+	Status      RunStatus     `json:"status,omitempty"`
+	ExitCode    int           `json:"exitCode"`
+	Error       string        `json:"error,omitempty"`
+	// PID identifies the OS process for an in-progress run, used to detect stale "running" records.
+	PID int `json:"pid,omitempty"`
 	// LogArchiveID links this record to a tuikit log archive entry for cross-referencing.
 	LogArchiveID string `json:"logArchiveId,omitempty"`
+
+	// Command is the shell command for an ad-hoc (transient) run; empty for named executables.
+	Command string `json:"command,omitempty"`
+	// Label is a human-readable, self-documenting name for an ad-hoc run.
+	Label string `json:"label,omitempty"`
+
+	// Provenance: who/what launched the run.
+	Source     string `json:"source,omitempty"`     // "cli" | "mcp"
+	ClientName string `json:"clientName,omitempty"` // e.g. "claude", "cursor"
+	SessionID  string `json:"sessionId,omitempty"`
 }
 
 // BackgroundRunStatus represents the state of a background run.
@@ -224,6 +266,12 @@ func (s *BoltDataStore) RecordExecution(record ExecutionRecord) error {
 			if err != nil {
 				return fmt.Errorf("failed to open ref bucket for %s: %w", record.Ref, err)
 			}
+			// When the record carries a stable ID, key by it so the start-write (running) and
+			// completion-write (terminal) for the same run overwrite in place. Records without an
+			// ID (legacy) fall back to an auto-incrementing sequence key (append-only).
+			if record.ID != "" {
+				return refBucket.Put([]byte(record.ID), data)
+			}
 			seq, err := refBucket.NextSequence()
 			if err != nil {
 				return fmt.Errorf("failed to generate sequence for %s: %w", record.Ref, err)
@@ -247,24 +295,28 @@ func (s *BoltDataStore) GetExecutionHistory(ref string, limit int) ([]ExecutionR
 			if refBucket == nil {
 				return nil
 			}
-			var all [][]byte
-			_ = refBucket.ForEach(func(_, v []byte) error {
-				cp := make([]byte, len(v))
-				copy(cp, v)
-				all = append(all, cp)
+			var all []ExecutionRecord
+			if err := refBucket.ForEach(func(_, v []byte) error {
+				var rec ExecutionRecord
+				if err := json.Unmarshal(v, &rec); err != nil {
+					return fmt.Errorf("failed to unmarshal execution record: %w", err)
+				}
+				all = append(all, rec)
 				return nil
+			}); err != nil {
+				return err
+			}
+			// Keys are no longer strictly chronological (records may be keyed by run ID), so sort
+			// by start time and keep the most recent `limit` entries. Stable sort preserves
+			// insertion order for records that share a timestamp (e.g. legacy seq-keyed records).
+			sort.SliceStable(all, func(i, j int) bool {
+				return all[i].StartedAt.Before(all[j].StartedAt)
 			})
 			start := 0
 			if limit > 0 && len(all) > limit {
 				start = len(all) - limit
 			}
-			for _, v := range all[start:] {
-				var rec ExecutionRecord
-				if err := json.Unmarshal(v, &rec); err != nil {
-					return fmt.Errorf("failed to unmarshal execution record: %w", err)
-				}
-				records = append(records, rec)
-			}
+			records = append(records, all[start:]...)
 			return nil
 		})
 	})

--- a/pkg/store/store_test.go
+++ b/pkg/store/store_test.go
@@ -140,6 +140,43 @@ var _ = Describe("BoltDataStore", func() {
 			Expect(ds.DeleteExecutionHistory("unknown/ns:exec")).To(Succeed())
 		})
 
+		It("should upsert records that share an ID (running -> terminal)", func() {
+			start := time.Now().UTC().Truncate(time.Millisecond)
+			Expect(ds.RecordExecution(store.ExecutionRecord{
+				ID:        "run-1",
+				Ref:       ref,
+				StartedAt: start,
+				Status:    store.RunRunning,
+				PID:       4242,
+			})).To(Succeed())
+
+			// Same ID upserts in place rather than appending a second record.
+			done := start.Add(time.Second)
+			Expect(ds.RecordExecution(store.ExecutionRecord{
+				ID:          "run-1",
+				Ref:         ref,
+				StartedAt:   start,
+				CompletedAt: &done,
+				Duration:    time.Second,
+				Status:      store.RunCompleted,
+			})).To(Succeed())
+
+			history, err := ds.GetExecutionHistory(ref, 0)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(history).To(HaveLen(1))
+			Expect(history[0].Status).To(Equal(store.RunCompleted))
+			Expect(history[0].CompletedAt).NotTo(BeNil())
+		})
+
+		It("should append records without an ID (legacy behavior)", func() {
+			Expect(ds.RecordExecution(store.ExecutionRecord{Ref: ref})).To(Succeed())
+			Expect(ds.RecordExecution(store.ExecutionRecord{Ref: ref})).To(Succeed())
+
+			history, err := ds.GetExecutionHistory(ref, 0)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(history).To(HaveLen(2))
+		})
+
 		It("should maintain separate history per ref", func() {
 			ref2 := "ws/ns:other"
 			Expect(ds.RecordExecution(store.ExecutionRecord{Ref: ref, ExitCode: 0})).To(Succeed())


### PR DESCRIPTION
## Summary

Makes flow usable as an agent's primary execution engine and turns its history into an observability surface. Three layers:

- **Lifecycle-aware history** — every run is recorded at *start* as `running` and updated to `completed`/`failed` at finish, so in-progress foreground runs are visible from any terminal (not just after they exit). Runs whose process dies are reconciled to `failed` on next view.
- **Provenance** — runs capture where they came from: `cli`, or `mcp` with the calling client name (`claude`, `cursor`, …) and session ID. `flow logs` gains `--source`/`--session`/`--client` filters and a lifecycle-aware `--status` (`running`/`completed`/`failed`, with `success`/`failure` aliases). Origin is surfaced in the TUI list (new **Origin** column), the plain-text list, and detail views.
- **Modernized MCP** — new `run_command` (arbitrary shell command(s), single or serial/parallel batch) and `run_executable` (transient executable of any type from an inline `spec`) tools, so agents run everything *through* flow with workspace env/secrets and a durable, attributable history entry. `get_execution_logs` exposes the same provenance filters plus `mine: true` (this session's own runs). The always-loaded tool surface was trimmed ~50% (output schemas pruned to the execution tools; server instructions slimmed) to lower context cost.

All three run tools (`execute`, `run_command`, `run_executable`) stamp provenance via a shared transient path. Per-run `workspace` scoping never mutates the global current workspace.

## Docs
- **AI Tools** guide: run tools, the pick-the-closest-tool ladder, and a new **Observability** section; refreshed Claude Code skill example.
- **Execution History** guide: lifecycle status + provenance filtering.
- `integrations.md` tool list and `llms.txt` descriptions updated; generated CLI docs regenerated.

## Testing
- Unit tests for the new filters (source/session/client, lifecycle status, case-insensitivity, AND-combining) and MCP filter pass-through.
- Live end-to-end: verified the running→completed lifecycle mid-flight, provenance recording, and every filter against seeded runs.
- `flow validate` green (generate → lint → unit → e2e → schemas), no generated drift.

## Notes
- Additive only — new `omitempty` record fields keep legacy history unmarshalling; `RecordExecution` upserts by run ID.
- Split cleanly off `main`; independent of the container-detail work on `jdoc/feat-container-exec-view`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)