### PR TITLE
feat(logs): fetch execution log output and fix background runs

### DIFF
--- a/cmd/internal/exec.go
+++ b/cmd/internal/exec.go
@@ -129,9 +129,7 @@ func execFunc(ctx *context.Context, cmd *cobra.Command, verb executable.Verb, ar
 	e, ref := resolveExecutableForRun(ctx, cmd, verb, args)
 
 	// Handle --background: spawn a detached child process and return immediately.
-	background := flags.ValueFor[bool](cmd, *flags.BackgroundFlag, false)
-	if background {
-		launchBackground(ctx, ref, verb, args)
+	if maybeLaunchBackground(ctx, cmd, ref) {
 		return
 	}
 
@@ -269,6 +267,9 @@ func execAdHoc(ctx *context.Context, cmd *cobra.Command, verb executable.Verb, c
 		}
 	}
 	setTransientContext(ctx, cmd, e, dir)
+	if maybeLaunchBackground(ctx, cmd, e.Ref()) {
+		return
+	}
 	runTransientExecutable(ctx, cmd, e, joined, label)
 }
 
@@ -276,6 +277,12 @@ func execAdHoc(ctx *context.Context, cmd *cobra.Command, verb executable.Verb, c
 // --cmd, the spec can be any executable type (exec, serial, parallel, request, render, launch); it
 // is never written to disk but runs through the normal engine and is recorded in history.
 func execTransientSpec(ctx *context.Context, cmd *cobra.Command, verb executable.Verb, spec string) {
+	// A detached background child inherits no stdin, so a spec piped via stdin can't be re-read.
+	if spec == "-" && flags.ValueFor[bool](cmd, *flags.BackgroundFlag, false) {
+		errhandler.HandleUsage(ctx, cmd, "--background cannot be combined with a --spec read from stdin ('-')")
+		return
+	}
+
 	content, err := resolveSpecContent(spec)
 	if err != nil {
 		errhandler.HandleFatal(ctx, cmd, err)
@@ -298,10 +305,27 @@ func execTransientSpec(ctx *context.Context, cmd *cobra.Command, verb executable
 	}
 
 	label := flags.ValueFor[string](cmd, *flags.LabelFlag, false)
+	// A spec may omit `name`; fall back to a ref-safe name derived from --label so history and
+	// the background-run record show a meaningful ref rather than an empty "verb ws/".
+	if e.Name == "" {
+		e.Name = transientSpecName(label)
+	}
 	if label == "" {
 		label = e.Name
 	}
+	if maybeLaunchBackground(ctx, cmd, e.Ref()) {
+		return
+	}
 	runTransientExecutable(ctx, cmd, e, "", label)
+}
+
+// transientSpecName derives a ref-safe name for a --spec run that omitted `name`, preferring the
+// --label and falling back to a generic default.
+func transientSpecName(label string) string {
+	if slug := slugify(label); slug != "" {
+		return "spec-" + slug
+	}
+	return "spec"
 }
 
 // resolveSpecContent resolves a --spec value into raw definition content: '-' reads stdin,
@@ -472,17 +496,32 @@ func slugify(s string) string {
 	return out
 }
 
-// launchBackground spawns a detached flow process for the given executable and returns immediately.
-func launchBackground(ctx *context.Context, ref executable.Ref, verb executable.Verb, args []string) {
+// maybeLaunchBackground spawns a detached child process for the run and returns true when it did,
+// signalling the caller to return without executing inline. It is a no-op (returns false) unless
+// --background is set and this process is not itself a background child — the latter guard prevents
+// the detached child, which re-runs the same command, from forking again forever.
+func maybeLaunchBackground(ctx *context.Context, cmd *cobra.Command, ref executable.Ref) bool {
+	if !flags.ValueFor[bool](cmd, *flags.BackgroundFlag, false) {
+		return false
+	}
+	if os.Getenv(backgroundRunIDEnv) != "" {
+		return false
+	}
+	launchBackground(ctx, ref)
+	return true
+}
+
+// launchBackground spawns a detached flow process for the current invocation and returns
+// immediately. The child re-runs this exact command (verb, args, and every flag) so ad-hoc
+// (--cmd), transient (--spec), and named executables all background identically.
+func launchBackground(ctx *context.Context, ref executable.Ref) {
 	runID := uuid.New().String()[:8]
 
-	// Build the child command: same verb + args. Stdout/stderr are set to nil so
-	// Go redirects them to /dev/null — terminal output is suppressed but the tuikit
-	// archive handler still writes to the log file normally.
-	childArgs := []string{string(verb)}
-	if len(args) > 0 {
-		childArgs = append(childArgs, args...)
-	}
+	// Reconstruct the child command from this process's own args, dropping only the background
+	// flag so the child runs inline. Stdout/stderr/stdin are nil so Go redirects them to
+	// /dev/null — terminal output is suppressed but the tuikit archive handler still writes to
+	// the log file normally.
+	childArgs := backgroundChildArgs(os.Args[1:])
 
 	flowBin, err := os.Executable()
 	if err != nil {
@@ -517,6 +556,32 @@ func launchBackground(ctx *context.Context, ref executable.Ref, verb executable.
 	_ = child.Process.Release()
 
 	logger.Log().Println(fmt.Sprintf("Started background run %s (PID %d) for %s", runID, run.PID, ref))
+}
+
+// backgroundChildArgs returns the CLI args for a detached child: the current process's args with
+// the --background/-b flag removed so the child executes inline instead of forking again. Both the
+// long and short forms are stripped, including the `--background=true` value form. Anything after a
+// `--` separator is passed through untouched so a passthrough arg to the target isn't mistaken for
+// the flag.
+func backgroundChildArgs(args []string) []string {
+	out := make([]string, 0, len(args))
+	passthrough := false
+	for _, a := range args {
+		if passthrough {
+			out = append(out, a)
+			continue
+		}
+		if a == "--" {
+			passthrough = true
+			out = append(out, a)
+			continue
+		}
+		if a == "--background" || a == "-b" || strings.HasPrefix(a, "--background=") {
+			continue
+		}
+		out = append(out, a)
+	}
+	return out
 }
 
 // linkBackgroundArchive eagerly writes the log archive path into the background run

--- a/cmd/internal/exec_internal_test.go
+++ b/cmd/internal/exec_internal_test.go
@@ -1,0 +1,65 @@
+package internal
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestBackgroundChildArgs_StripsBackgroundFlag(t *testing.T) {
+	cases := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{
+			name: "long form among ad-hoc flags",
+			in:   []string{"exec", "--cmd", "echo hi", "--background", "--label", "x"},
+			want: []string{"exec", "--cmd", "echo hi", "--label", "x"},
+		},
+		{
+			name: "short form with a named executable",
+			in:   []string{"run", "build", "-b"},
+			want: []string{"run", "build"},
+		},
+		{
+			name: "explicit value form",
+			in:   []string{"exec", "--cmd", "echo hi", "--background=true"},
+			want: []string{"exec", "--cmd", "echo hi"},
+		},
+		{
+			name: "no background flag is a passthrough",
+			in:   []string{"run", "build", "--", "--arg"},
+			want: []string{"run", "build", "--", "--arg"},
+		},
+		{
+			name: "preserves args after a -- separator",
+			in:   []string{"run", "test", "--background", "--", "-v", "--run", "TestX"},
+			want: []string{"run", "test", "--", "-v", "--run", "TestX"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := backgroundChildArgs(tc.in)
+			if !slices.Equal(got, tc.want) {
+				t.Fatalf("backgroundChildArgs(%v) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestTransientSpecName(t *testing.T) {
+	cases := map[string]string{
+		"":              "spec",
+		"   ":           "spec",
+		"Deploy API":    "spec-deploy-api",
+		"my-run":        "spec-my-run",
+		"!!!":           "spec",
+		"nightly_build": "spec-nightly-build",
+	}
+	for label, want := range cases {
+		if got := transientSpecName(label); got != want {
+			t.Fatalf("transientSpecName(%q) = %q, want %q", label, got, want)
+		}
+	}
+}

--- a/cmd/internal/flags/types.go
+++ b/cmd/internal/flags/types.go
@@ -248,6 +248,34 @@ var LogFilterLimitFlag = &Metadata{
 	Required: false,
 }
 
+var LogContentFlag = &Metadata{
+	Name:     "content",
+	Usage:    "Include each record's log output (json/yaml only; already shown for --last text output).",
+	Default:  false,
+	Required: false,
+}
+
+var LogTailFlag = &Metadata{
+	Name:     "tail",
+	Usage:    "Include only the last N lines of log output (implies --content).",
+	Default:  0,
+	Required: false,
+}
+
+var LogGrepFlag = &Metadata{
+	Name:     "grep",
+	Usage:    "Include only log lines matching this regular expression (implies --content).",
+	Default:  "",
+	Required: false,
+}
+
+var LogMaxBytesFlag = &Metadata{
+	Name:     "max-bytes",
+	Usage:    "Cap included log output to the last N bytes, keeping the tail (implies --content).",
+	Default:  0,
+	Required: false,
+}
+
 var TemplateWorkspaceFlag = &Metadata{
 	Name:      "workspace",
 	Shorthand: "w",

--- a/cmd/internal/logs.go
+++ b/cmd/internal/logs.go
@@ -47,6 +47,10 @@ func RegisterLogsCmd(ctx *context.Context, rootCmd *cobra.Command) {
 	RegisterFlag(ctx, subCmd, *flags.LogFilterClientFlag)
 	RegisterFlag(ctx, subCmd, *flags.LogFilterSinceFlag)
 	RegisterFlag(ctx, subCmd, *flags.LogFilterLimitFlag)
+	RegisterFlag(ctx, subCmd, *flags.LogContentFlag)
+	RegisterFlag(ctx, subCmd, *flags.LogTailFlag)
+	RegisterFlag(ctx, subCmd, *flags.LogGrepFlag)
+	RegisterFlag(ctx, subCmd, *flags.LogMaxBytesFlag)
 
 	clearCmd := &cobra.Command{
 		Use:   "clear [ref]",
@@ -120,14 +124,30 @@ func logFunc(ctx *context.Context, cmd *cobra.Command, args []string) {
 		return
 	}
 
+	contentOpts, includeContent := buildContentOptions(cmd)
+
 	if lastEntry {
 		if len(records) == 0 {
 			logger.Log().Fatalf("No execution history found")
 		}
-		logs.PrintLastRecord(outputFormat, records[0], ctx.StdOut())
+		logs.PrintLastRecord(outputFormat, records[0], ctx.StdOut(), contentOpts, includeContent)
 	} else {
-		logs.PrintRecords(outputFormat, records)
+		logs.PrintRecords(outputFormat, records, contentOpts, includeContent)
 	}
+}
+
+// buildContentOptions reads the log-content flags into a ContentOptions and reports whether
+// log output should be included in json/yaml output. Any of --tail/--grep/--max-bytes implies
+// content inclusion, matching their "implies --content" flag documentation.
+func buildContentOptions(cmd *cobra.Command) (logs.ContentOptions, bool) {
+	opts := logs.ContentOptions{
+		Tail:     flags.ValueFor[int](cmd, *flags.LogTailFlag, false),
+		Grep:     flags.ValueFor[string](cmd, *flags.LogGrepFlag, false),
+		MaxBytes: flags.ValueFor[int](cmd, *flags.LogMaxBytesFlag, false),
+	}
+	includeContent := flags.ValueFor[bool](cmd, *flags.LogContentFlag, false) ||
+		opts.Tail > 0 || opts.Grep != "" || opts.MaxBytes > 0
+	return opts, includeContent
 }
 
 // durationWithDays extends time.ParseDuration to support a "d" (day) suffix.
@@ -381,4 +401,6 @@ const logsExamples = `
   flow logs --session <id>           # everything one agent session ran
   flow logs run build                # history for 'run build' executable
   flow logs --running                # list active background processes
+  flow logs -o json --tail 50        # include the last 50 lines of each run's output
+  flow logs --last --grep ERROR      # last run, only lines matching /ERROR/
 `

--- a/docs/cli/flow_logs.md
+++ b/docs/cli/flow_logs.md
@@ -22,6 +22,8 @@ flow logs [ref] [flags]
   flow logs --session <id>           # everything one agent session ran
   flow logs run build                # history for 'run build' executable
   flow logs --running                # list active background processes
+  flow logs -o json --tail 50        # include the last 50 lines of each run's output
+  flow logs --last --grep ERROR      # last run, only lines matching /ERROR/
 
 ```
 
@@ -29,15 +31,19 @@ flow logs [ref] [flags]
 
 ```
       --client string      Filter history by the client that launched the run (e.g. 'claude', 'cursor').
+      --content            Include each record's log output (json/yaml only; already shown for --last text output).
+      --grep string        Include only log lines matching this regular expression (implies --content).
   -h, --help               help for logs
       --last               Print the last execution's logs
       --limit int          Maximum number of records to display.
+      --max-bytes int      Cap included log output to the last N bytes, keeping the tail (implies --content).
   -o, --output string      Output format. One of: yaml, json, or tui.
       --running            Show only active background processes.
       --session string     Filter history to a single provenance session ID (e.g. an AI agent session).
       --since string       Filter history to entries after a duration (e.g. 1h, 30m, 7d).
       --source string      Filter history by run origin: 'cli' or 'mcp'.
       --status string      Filter history by status (running, completed, or failed; success/failure accepted as aliases).
+      --tail int           Include only the last N lines of log output (implies --content).
   -w, --workspace string   Filter history by workspace name.
 ```
 

--- a/internal/io/logs/content.go
+++ b/internal/io/logs/content.go
@@ -1,0 +1,80 @@
+package logs
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// ContentOptions controls how a record's log output is sliced for display.
+// The operations apply in order — grep filter, then tail, then byte cap — and
+// each limit keeps the END of the log, since failures surface there.
+type ContentOptions struct {
+	// Tail limits output to the last N lines (applied after Grep). 0 means no line limit.
+	Tail int
+	// Grep keeps only lines matching this regular expression. Empty means no filter.
+	Grep string
+	// MaxBytes caps the returned content to the last N bytes, trimmed to a line
+	// boundary where possible. 0 means no byte cap.
+	MaxBytes int
+}
+
+// ContentResult is the outcome of slicing a record's raw log output.
+type ContentResult struct {
+	Content       string
+	TotalLines    int  // lines in the raw log (before any filtering)
+	ReturnedLines int  // lines in the returned content
+	Truncated     bool // returned content omits part of the log due to the tail/byte limits
+}
+
+// ExtractContent applies the slicing options to a raw log string. With zero-valued
+// options it returns the content unchanged. It is safe to call on partial logs from
+// still-running executions — it simply operates on whatever has been written so far.
+func ExtractContent(raw string, opts ContentOptions) (ContentResult, error) {
+	var res ContentResult
+	if raw == "" {
+		return res, nil
+	}
+
+	// Split into lines without a trailing empty element from a final newline.
+	lines := strings.Split(strings.TrimSuffix(raw, "\n"), "\n")
+	res.TotalLines = len(lines)
+
+	if opts.Grep != "" {
+		re, err := regexp.Compile(opts.Grep)
+		if err != nil {
+			return res, fmt.Errorf("invalid grep pattern %q: %w", opts.Grep, err)
+		}
+		matched := make([]string, 0, len(lines))
+		for _, ln := range lines {
+			if re.MatchString(ln) {
+				matched = append(matched, ln)
+			}
+		}
+		lines = matched
+	}
+
+	if opts.Tail > 0 && len(lines) > opts.Tail {
+		lines = lines[len(lines)-opts.Tail:]
+		res.Truncated = true
+	}
+
+	content := strings.Join(lines, "\n")
+
+	if opts.MaxBytes > 0 && len(content) > opts.MaxBytes {
+		// Keep the tail: trim from the front, advancing to the next line boundary
+		// so the leading line isn't left mangled (unless there is no newline left).
+		cut := len(content) - opts.MaxBytes
+		if nl := strings.IndexByte(content[cut:], '\n'); nl >= 0 {
+			cut += nl + 1
+		}
+		content = content[cut:]
+		res.Truncated = true
+	}
+
+	res.Content = content
+	if content != "" {
+		res.ReturnedLines = strings.Count(content, "\n") + 1
+	}
+	return res, nil
+}

--- a/internal/io/logs/content_test.go
+++ b/internal/io/logs/content_test.go
@@ -1,0 +1,144 @@
+package logs_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/flowexec/flow/v2/internal/io/logs"
+)
+
+func TestExtractContent_EmptyReturnsZeroValue(t *testing.T) {
+	res, err := logs.ExtractContent("", logs.ContentOptions{Tail: 10})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Content != "" || res.TotalLines != 0 || res.ReturnedLines != 0 || res.Truncated {
+		t.Fatalf("expected zero-valued result, got %+v", res)
+	}
+}
+
+func TestExtractContent_NoOptionsReturnsFull(t *testing.T) {
+	raw := "a\nb\nc"
+	res, err := logs.ExtractContent(raw, logs.ContentOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Content != raw {
+		t.Fatalf("expected content %q, got %q", raw, res.Content)
+	}
+	if res.TotalLines != 3 || res.ReturnedLines != 3 || res.Truncated {
+		t.Fatalf("unexpected result %+v", res)
+	}
+}
+
+func TestExtractContent_TrailingNewlineNotCountedAsLine(t *testing.T) {
+	res, err := logs.ExtractContent("a\nb\n", logs.ContentOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.TotalLines != 2 {
+		t.Fatalf("expected 2 lines, got %d", res.TotalLines)
+	}
+}
+
+func TestExtractContent_TailKeepsLastLines(t *testing.T) {
+	raw := "1\n2\n3\n4\n5"
+	res, err := logs.ExtractContent(raw, logs.ContentOptions{Tail: 2})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Content != "4\n5" {
+		t.Fatalf("expected last two lines, got %q", res.Content)
+	}
+	if !res.Truncated {
+		t.Fatalf("expected truncated=true")
+	}
+	if res.TotalLines != 5 || res.ReturnedLines != 2 {
+		t.Fatalf("unexpected counts %+v", res)
+	}
+}
+
+func TestExtractContent_TailLargerThanLogNotTruncated(t *testing.T) {
+	res, err := logs.ExtractContent("1\n2", logs.ContentOptions{Tail: 10})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Truncated {
+		t.Fatalf("expected not truncated when tail exceeds line count")
+	}
+	if res.Content != "1\n2" {
+		t.Fatalf("expected full content, got %q", res.Content)
+	}
+}
+
+func TestExtractContent_GrepFiltersLines(t *testing.T) {
+	raw := "info: ok\nERROR: boom\ninfo: still ok\nERROR: kaboom"
+	res, err := logs.ExtractContent(raw, logs.ContentOptions{Grep: "^ERROR"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Content != "ERROR: boom\nERROR: kaboom" {
+		t.Fatalf("unexpected grep result %q", res.Content)
+	}
+	// Grep alone is a filter, not truncation.
+	if res.Truncated {
+		t.Fatalf("expected grep-only result to not be marked truncated")
+	}
+	if res.TotalLines != 4 || res.ReturnedLines != 2 {
+		t.Fatalf("unexpected counts %+v", res)
+	}
+}
+
+func TestExtractContent_GrepThenTail(t *testing.T) {
+	raw := "ERROR: 1\nok\nERROR: 2\nok\nERROR: 3"
+	res, err := logs.ExtractContent(raw, logs.ContentOptions{Grep: "ERROR", Tail: 2})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Content != "ERROR: 2\nERROR: 3" {
+		t.Fatalf("expected last two matching lines, got %q", res.Content)
+	}
+	if !res.Truncated {
+		t.Fatalf("expected truncated after tailing matches")
+	}
+}
+
+func TestExtractContent_InvalidGrepReturnsError(t *testing.T) {
+	_, err := logs.ExtractContent("a\nb", logs.ContentOptions{Grep: "("})
+	if err == nil {
+		t.Fatalf("expected error for invalid regexp")
+	}
+}
+
+func TestExtractContent_MaxBytesKeepsTailOnLineBoundary(t *testing.T) {
+	// Lines of 4 bytes each ("aaa\n"). Cap to keep only the final line's worth.
+	raw := "aaaa\nbbbb\ncccc"
+	res, err := logs.ExtractContent(raw, logs.ContentOptions{MaxBytes: 6})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Content != "cccc" {
+		t.Fatalf("expected trailing line aligned to boundary, got %q", res.Content)
+	}
+	if !res.Truncated {
+		t.Fatalf("expected truncated=true when byte cap trims content")
+	}
+	if strings.Contains(res.Content, "\n") && res.ReturnedLines != strings.Count(res.Content, "\n")+1 {
+		t.Fatalf("returned line count mismatch: %+v", res)
+	}
+}
+
+func TestExtractContent_MaxBytesKeepsPartialLineWhenNoBoundary(t *testing.T) {
+	// A single very long line with no newline: keep the last MaxBytes bytes rather than nothing.
+	raw := strings.Repeat("x", 100)
+	res, err := logs.ExtractContent(raw, logs.ContentOptions{MaxBytes: 10})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(res.Content) != 10 {
+		t.Fatalf("expected 10 trailing bytes, got %d", len(res.Content))
+	}
+	if !res.Truncated {
+		t.Fatalf("expected truncated=true")
+	}
+}

--- a/internal/io/logs/join_internal_test.go
+++ b/internal/io/logs/join_internal_test.go
@@ -1,0 +1,82 @@
+package logs
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/flowexec/flow/v2/pkg/store"
+)
+
+// writeArchive creates an archive log file named "<id>__<ts>.log" with content, mirroring
+// the tuikit archive naming so ListArchiveEntries can parse and index it.
+func writeArchive(t *testing.T, dir, id, content string) string {
+	t.Helper()
+	name := id + "__2024-01-02-03-04-05.log"
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write archive: %v", err)
+	}
+	return path
+}
+
+func TestJoinRecords_InProgressResolvesByID(t *testing.T) {
+	dir := t.TempDir()
+	// A running record carries only its archive ID (no resolved path yet), the way
+	// recordRunStart writes it before completion.
+	writeArchive(t, dir, "run-abc", "partial output so far\n")
+
+	idx := buildArchiveIndex(dir)
+	records := []store.ExecutionRecord{{
+		ID:        "run-abc",
+		Ref:       "run ws/ns:thing",
+		Status:    store.RunRunning,
+		StartedAt: time.Now(),
+		// LogArchiveID (the resolved path) intentionally empty — set only on completion.
+	}}
+
+	unified := joinRecords(records, idx)
+	if len(unified) != 1 {
+		t.Fatalf("expected 1 record, got %d", len(unified))
+	}
+	if unified[0].LogEntry == nil {
+		t.Fatalf("expected in-progress record to resolve a log entry by ID")
+	}
+	got, err := unified[0].LogEntry.Read()
+	if err != nil {
+		t.Fatalf("read log entry: %v", err)
+	}
+	if got != "partial output so far\n" {
+		t.Fatalf("unexpected content %q", got)
+	}
+}
+
+func TestJoinRecords_CompletedResolvesByPath(t *testing.T) {
+	dir := t.TempDir()
+	path := writeArchive(t, dir, "run-done", "final output\n")
+
+	idx := buildArchiveIndex(dir)
+	records := []store.ExecutionRecord{{
+		ID:           "run-done",
+		Ref:          "run ws/ns:thing",
+		Status:       store.RunCompleted,
+		LogArchiveID: path, // completed records store the resolved path
+		StartedAt:    time.Now(),
+	}}
+
+	unified := joinRecords(records, idx)
+	if unified[0].LogEntry == nil || unified[0].LogEntry.Path != path {
+		t.Fatalf("expected completed record to resolve by path, got %+v", unified[0].LogEntry)
+	}
+}
+
+func TestJoinRecords_NoArchiveLeavesEntryNil(t *testing.T) {
+	dir := t.TempDir()
+	idx := buildArchiveIndex(dir)
+	records := []store.ExecutionRecord{{ID: "missing", Ref: "run ws/ns:x", StartedAt: time.Now()}}
+	unified := joinRecords(records, idx)
+	if unified[0].LogEntry != nil {
+		t.Fatalf("expected nil log entry when no archive exists")
+	}
+}

--- a/internal/io/logs/output.go
+++ b/internal/io/logs/output.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"time"
 
+	tuikitIO "github.com/flowexec/tuikit/io"
 	"gopkg.in/yaml.v3"
 
 	"github.com/flowexec/flow/v2/internal/io/common"
@@ -25,13 +26,19 @@ type recordOutput struct {
 	Source     string `json:"source,omitempty"     yaml:"source,omitempty"`
 	ClientName string `json:"clientName,omitempty" yaml:"clientName,omitempty"`
 	SessionID  string `json:"sessionId,omitempty"  yaml:"sessionId,omitempty"`
+
+	// Content and its companions are populated only when log content is requested.
+	Content              string `json:"content,omitempty"              yaml:"content,omitempty"`
+	ContentTruncated     bool   `json:"contentTruncated,omitempty"     yaml:"contentTruncated,omitempty"`
+	ContentTotalLines    int    `json:"contentTotalLines,omitempty"    yaml:"contentTotalLines,omitempty"`
+	ContentReturnedLines int    `json:"contentReturnedLines,omitempty" yaml:"contentReturnedLines,omitempty"`
 }
 
 type recordsResponse struct {
 	History []recordOutput `json:"history" yaml:"history"`
 }
 
-func toRecordOutput(r UnifiedRecord) recordOutput {
+func toRecordOutput(r UnifiedRecord, content ContentOptions, includeContent bool) recordOutput {
 	out := recordOutput{
 		Ref:        r.Ref,
 		StartedAt:  r.StartedAt.Format(time.RFC3339),
@@ -47,15 +54,36 @@ func toRecordOutput(r UnifiedRecord) recordOutput {
 	}
 	if r.LogEntry != nil {
 		out.LogFile = r.LogEntry.Path
+		if includeContent {
+			applyContent(&out, *r.LogEntry, content)
+		}
 	}
 	return out
 }
 
+// applyContent reads the archive entry's output, slices it per opts, and populates the
+// content fields on out. Read/filter errors are non-fatal — the metadata still stands.
+func applyContent(out *recordOutput, entry tuikitIO.ArchiveEntry, opts ContentOptions) {
+	raw, err := entry.Read()
+	if err != nil {
+		return
+	}
+	res, err := ExtractContent(raw, opts)
+	if err != nil {
+		return
+	}
+	out.Content = res.Content
+	out.ContentTruncated = res.Truncated
+	out.ContentTotalLines = res.TotalLines
+	out.ContentReturnedLines = res.ReturnedLines
+}
+
 // PrintRecords outputs unified records in the specified format (json, yaml, or plain text).
-func PrintRecords(format string, records []UnifiedRecord) {
+// When includeContent is set, each record's log output is read and sliced per content.
+func PrintRecords(format string, records []UnifiedRecord, content ContentOptions, includeContent bool) {
 	out := make([]recordOutput, len(records))
 	for i, r := range records {
-		out[i] = toRecordOutput(r)
+		out[i] = toRecordOutput(r, content, includeContent)
 	}
 
 	switch common.NormalizeFormat(format) {
@@ -93,9 +121,13 @@ func printRecordsText(records []UnifiedRecord) {
 	}
 }
 
-// PrintLastRecord outputs metadata and log content for a single record.
-func PrintLastRecord(format string, record UnifiedRecord, stdout io.Writer) {
-	out := toRecordOutput(record)
+// PrintLastRecord outputs metadata and log content for a single record. In text mode the
+// full log is printed (sliced per content when any content option is set); in json/yaml the
+// content fields are populated only when includeContent is set.
+func PrintLastRecord(
+	format string, record UnifiedRecord, stdout io.Writer, content ContentOptions, includeContent bool,
+) {
+	out := toRecordOutput(record, content, includeContent)
 
 	switch common.NormalizeFormat(format) {
 	case common.JSONFormat:
@@ -136,11 +168,24 @@ func PrintLastRecord(format string, record UnifiedRecord, stdout io.Writer) {
 		_, _ = fmt.Fprintln(stdout)
 
 		if record.LogEntry != nil {
-			content, err := record.LogEntry.Read()
-			if err != nil {
+			raw, err := record.LogEntry.Read()
+			switch {
+			case err != nil:
 				_, _ = fmt.Fprintf(stdout, "error reading log: %v\n", err)
-			} else if content != "" {
-				_, _ = fmt.Fprint(stdout, content)
+			case raw != "":
+				res, extractErr := ExtractContent(raw, content)
+				if extractErr != nil {
+					_, _ = fmt.Fprintf(stdout, "error filtering log: %v\n", extractErr)
+					break
+				}
+				_, _ = fmt.Fprint(stdout, res.Content)
+				if res.Truncated {
+					_, _ = fmt.Fprintf(
+						stdout,
+						"\n... (showing %d of %d lines)\n",
+						res.ReturnedLines, res.TotalLines,
+					)
+				}
 			}
 		}
 	}

--- a/internal/io/logs/records.go
+++ b/internal/io/logs/records.go
@@ -199,28 +199,42 @@ func getAllExecutionHistory(ds store.DataStore) ([]store.ExecutionRecord, error)
 	return all, nil
 }
 
-// buildArchiveIndex loads log archive entries from disk and indexes them by path for O(1) lookup.
-func buildArchiveIndex(logsDir string) map[string]tuikitIO.ArchiveEntry {
+// archiveIndex indexes log archive entries for O(1) lookup by both their on-disk
+// path and their archive ID, so records can be resolved by whichever they carry.
+type archiveIndex struct {
+	byPath map[string]tuikitIO.ArchiveEntry
+	byID   map[string]tuikitIO.ArchiveEntry
+}
+
+// buildArchiveIndex loads log archive entries from disk and indexes them by path and by ID.
+func buildArchiveIndex(logsDir string) archiveIndex {
+	idx := archiveIndex{
+		byPath: map[string]tuikitIO.ArchiveEntry{},
+		byID:   map[string]tuikitIO.ArchiveEntry{},
+	}
 	entries, err := tuikitIO.ListArchiveEntries(logsDir)
-	if err != nil || len(entries) == 0 {
-		return nil
+	if err != nil {
+		return idx
 	}
-	index := make(map[string]tuikitIO.ArchiveEntry, len(entries))
 	for _, e := range entries {
-		index[e.Path] = e
+		idx.byPath[e.Path] = e
+		idx.byID[e.ID] = e
 	}
-	return index
+	return idx
 }
 
 // joinRecords merges execution records with their log archive entries and sorts by StartedAt descending.
-func joinRecords(records []store.ExecutionRecord, archiveIndex map[string]tuikitIO.ArchiveEntry) []UnifiedRecord {
+func joinRecords(records []store.ExecutionRecord, idx archiveIndex) []UnifiedRecord {
 	unified := make([]UnifiedRecord, 0, len(records))
 	for _, r := range records {
 		ur := UnifiedRecord{ExecutionRecord: r}
-		if archiveIndex != nil {
-			if entry, ok := archiveIndex[r.LogArchiveID]; ok {
-				ur.LogEntry = &entry
-			}
+		if entry, ok := idx.byPath[r.LogArchiveID]; ok {
+			ur.LogEntry = &entry
+		} else if entry, ok := idx.byID[r.ID]; ok {
+			// In-progress records store only the archive ID — the resolved path is
+			// written on completion — so fall back to an ID match to make the live
+			// log file of a still-running execution readable.
+			ur.LogEntry = &entry
 		}
 		unified = append(unified, ur)
 	}

--- a/internal/mcp/output_types.go
+++ b/internal/mcp/output_types.go
@@ -110,6 +110,14 @@ type LogEntry struct {
 	Source     string `json:"source,omitempty"`
 	ClientName string `json:"clientName,omitempty"`
 	SessionID  string `json:"sessionId,omitempty"`
+
+	// Content and its companions are populated only when log output is requested
+	// (via the tail/grep/content parameters). Content is sliced to the requested
+	// window; ContentTruncated reports whether any of the log was omitted.
+	Content              string `json:"content,omitempty"`
+	ContentTruncated     bool   `json:"contentTruncated,omitempty"`
+	ContentTotalLines    int    `json:"contentTotalLines,omitempty"`
+	ContentReturnedLines int    `json:"contentReturnedLines,omitempty"`
 }
 
 // LogListOutput is the output of the get_execution_logs tool.

--- a/internal/mcp/resources/server-instructions.md
+++ b/internal/mcp/resources/server-instructions.md
@@ -18,6 +18,8 @@ Prefer running work **through flow** over a raw shell tool — you get the works
 
 Every run you launch is attributed to this session. `get_execution_logs` with `mine: true` returns only what *this* session has run — use it to review your own recent work; `source`/`session`/`status` filter more broadly.
 
+By default `get_execution_logs` returns only run **metadata** (ref, status, exitCode, error). To read the captured **output**, set `tail` (last N lines — best for debugging, since errors surface at the end), `grep` (a regex to pull just the matching lines out of a large log), or `content: true` (the whole log). Output is always byte-capped to protect the context window; `contentTruncated` in the response tells you when part of a log was omitted (widen with `tail`/`grep`/`max_bytes`, or open `logFile` directly). This reads the log live, so it also works on a **still-running** execution — you get a snapshot of what has been written so far.
+
 ## Notes
 
 - `execute` runs a defined executable, not a raw command — use `run_command` for arbitrary commands. If the executable defines `args`, pass them in `args`; if it defines prompt `params`, pass them in `params` as an EnvKey→value map.

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -410,6 +410,41 @@ var _ = Describe("MCP Server", func() {
 
 				Expect(err).ToNot(HaveOccurred())
 			})
+
+			It("should request content with the default byte cap when tail is set", func() {
+				mockExecutor.EXPECT().
+					Execute("logs", "--output", "json", "--content", "--max-bytes", "50000", "--tail", "20").
+					Return(`{"history":[]}`, nil)
+
+				_, err := mcpClient.CallTool(ctx, newCallToolRequest("get_execution_logs", map[string]interface{}{
+					"tail": 20,
+				}))
+
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("should forward grep and clamp an oversized max_bytes", func() {
+				mockExecutor.EXPECT().
+					Execute("logs", "--output", "json", "--content", "--max-bytes", "200000", "--grep", "error").
+					Return(`{"history":[]}`, nil)
+
+				_, err := mcpClient.CallTool(ctx, newCallToolRequest("get_execution_logs", map[string]interface{}{
+					"grep":      "error",
+					"max_bytes": 999999,
+				}))
+
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("should not request content when no content option is set", func() {
+				mockExecutor.EXPECT().
+					Execute("logs", "--output", "json").
+					Return(`{"history":[]}`, nil)
+
+				_, err := mcpClient.CallTool(ctx, newCallToolRequest("get_execution_logs", map[string]interface{}{}))
+
+				Expect(err).ToNot(HaveOccurred())
+			})
 		})
 
 		Context("sync_executables tool", func() {

--- a/internal/mcp/tools_system.go
+++ b/internal/mcp/tools_system.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strconv"
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
@@ -41,8 +42,11 @@ func addSystemTools(srv *server.MCPServer, executor CommandExecutor) {
 	srv.AddTool(getFlowInfo, getInfoHandler)
 
 	getExecutionLogs := mcp.NewTool("get_execution_logs",
-		mcp.WithDescription("Retrieve output from recent flow executions. "+
+		mcp.WithDescription("Retrieve metadata and output from recent flow executions. "+
 			"Use when debugging a failed run or when the user asks about the results of a previous task. "+
+			"By default only run metadata is returned (ref, status, exitCode, error) — set `tail`, `grep`, "+
+			"or `content` to include the captured log output. Output is read live, so it works on "+
+			"still-running executions too (you get a snapshot of what has been written so far). "+
 			"Set `mine` to see only what this session has run so far."),
 		mcp.WithBoolean("last", mcp.Description("Get only the last execution logs")),
 		mcp.WithBoolean("mine", mcp.Description("Only return runs launched by this MCP session "+
@@ -51,6 +55,15 @@ func addSystemTools(srv *server.MCPServer, executor CommandExecutor) {
 		mcp.WithString("session", mcp.Description("Filter to a single provenance session ID.")),
 		mcp.WithString("status", mcp.Description("Filter by status: running, completed, or failed.")),
 		mcp.WithString("cursor", mcp.Description("Pagination cursor for next page of results")),
+		mcp.WithBoolean("content", mcp.Description("Include each run's captured log output. Implied by "+
+			"`tail` or `grep`. Output is always capped (see `max_bytes`) to protect the context window.")),
+		mcp.WithNumber("tail", mcp.Description("Include only the last N lines of log output. Recommended "+
+			"for debugging since errors surface at the end of a log. Implies `content`.")),
+		mcp.WithString("grep", mcp.Description("Include only log lines matching this regular expression "+
+			"(applied before `tail`). Use to pull just the error lines out of a large log. Implies `content`.")),
+		mcp.WithNumber("max_bytes", mcp.Description(fmt.Sprintf(
+			"Cap the log output returned per run to the last N bytes. Defaults to %d and is hard-capped "+
+				"at %d to protect the context window.", defaultLogContentMaxBytes, maxLogContentMaxBytes))),
 	)
 	getExecutionLogs.Annotations = mcp.ToolAnnotation{
 		Title:           "Get execution logs",
@@ -122,6 +135,13 @@ func getInfoHandler(_ context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResu
 	return mcp.NewToolResultStructured(output, string(jsonData)), nil
 }
 
+// Log-content byte caps enforced server-side so an under-specified request can't flood the
+// context window with an unbounded log dump.
+const (
+	defaultLogContentMaxBytes = 50_000
+	maxLogContentMaxBytes     = 200_000
+)
+
 func getExecutionLogsHandler(executor CommandExecutor) server.ToolHandlerFunc {
 	return func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		last := request.GetBool("last", false)
@@ -153,6 +173,7 @@ func getExecutionLogsHandler(executor CommandExecutor) server.ToolHandlerFunc {
 		if status != "" {
 			cmdArgs = append(cmdArgs, "--status", status)
 		}
+		cmdArgs = append(cmdArgs, logContentArgs(request)...)
 
 		output, err := executor.Execute(cmdArgs...)
 		if err != nil {
@@ -195,6 +216,35 @@ func getExecutionLogsHandler(executor CommandExecutor) server.ToolHandlerFunc {
 		jsonData, _ := json.Marshal(result)
 		return mcp.NewToolResultStructured(result, string(jsonData)), nil
 	}
+}
+
+// logContentArgs translates the content-related request parameters into `flow logs` flags.
+// It returns no flags unless content was requested (via content/tail/grep), and always
+// enforces a byte cap — clamped into [1, maxLogContentMaxBytes] — so an under-specified
+// request can't flood the context window with an unbounded log dump.
+func logContentArgs(request mcp.CallToolRequest) []string {
+	tail := request.GetInt("tail", 0)
+	grep := request.GetString("grep", "")
+	if !request.GetBool("content", false) && tail <= 0 && grep == "" {
+		return nil
+	}
+
+	maxBytes := request.GetInt("max_bytes", 0)
+	if maxBytes <= 0 {
+		maxBytes = defaultLogContentMaxBytes
+	}
+	if maxBytes > maxLogContentMaxBytes {
+		maxBytes = maxLogContentMaxBytes
+	}
+
+	args := []string{"--content", "--max-bytes", strconv.Itoa(maxBytes)}
+	if tail > 0 {
+		args = append(args, "--tail", strconv.Itoa(tail))
+	}
+	if grep != "" {
+		args = append(args, "--grep", grep)
+	}
+	return args
 }
 
 func syncStateHandler(srv *server.MCPServer, executor CommandExecutor) server.ToolHandlerFunc {


### PR DESCRIPTION
## Summary

Three related changes to execution logs and background runs, driven by an agent's-eye view of the `get_execution_logs` MCP tool.

### 1. Fetch log **output**, not just metadata (+ truncation)
`get_execution_logs` / `flow logs` previously returned only run metadata (ref, status, exitCode, error) and a `logFile` path — never the captured output. Now:
- New `tail`, `grep`, `content` (and `max_bytes`) options slice a run's output, each keeping the **end** of the log where failures surface.
- Output is **byte-capped**; for MCP the cap is enforced server-side (default 50 KB, hard-capped 200 KB) so an under-specified request can't flood an agent's context window.
- Response reports `contentTruncated` / `contentTotalLines` / `contentReturnedLines` so the caller always knows it's seeing a slice.
- Reading is **live**, so it works on **still-running** executions — a running record now resolves its log file by archive **ID** (the resolved path is only written on completion), giving a snapshot of what's been written so far.

Default behavior is unchanged: with no content option, only metadata is returned, so listing stays cheap.

### 2. Fix `flow exec --background`
`--background` silently ran **inline** for `--cmd` and `--spec` (the ad-hoc/spec dispatch returned before the background check), and even on the named path `launchBackground` rebuilt the child from just `verb + args`, dropping every flag. Now the detached child is reconstructed from the full arg list with only the background flag stripped, so named / `--cmd` / `--spec` runs all background identically and every flag propagates. `--spec -` (stdin) + `--background` is rejected with a clear message (a detached child has no stdin to re-read).

### 3. Nameless `--spec` ref fallback
A `--spec` without a `name:` produced an empty ref (`exec flow/`). It now falls back to `spec-<slugified-label>` (or `spec`), mirroring `--cmd`'s `adhoc-` naming, so history and the background-run line show a meaningful ref.

## Testing
- `flow validate` passes locally: generate → lint → unit + e2e tests → schema validation.
- New unit tests: `ExtractContent` slicing (tail/grep/byte-cap/boundaries), in-progress join-by-ID, `backgroundChildArgs`, `transientSpecName`, plus MCP handler arg-forwarding/cap-clamping cases.
- Verified end-to-end: live tail of a running background run, `--background` detaching for `--cmd`/`--spec`, and the spec-name fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)