### PR TITLE
fix(vault): harden secret handling and reconcile vault listing

### DIFF
--- a/cmd/internal/vault.go
+++ b/cmd/internal/vault.go
@@ -8,7 +8,6 @@ import (
 	"github.com/flowexec/tuikit/views"
 	extvault "github.com/flowexec/vault"
 	"github.com/spf13/cobra"
-	"golang.org/x/exp/maps"
 
 	errhandler "github.com/flowexec/flow/v2/cmd/internal/errors"
 	"github.com/flowexec/flow/v2/cmd/internal/flags"
@@ -19,7 +18,6 @@ import (
 	"github.com/flowexec/flow/v2/pkg/context"
 	"github.com/flowexec/flow/v2/pkg/filesystem"
 	"github.com/flowexec/flow/v2/pkg/logger"
-	"github.com/flowexec/flow/v2/types/config"
 )
 
 func RegisterVaultCmd(ctx *context.Context, rootCmd *cobra.Command) {
@@ -55,7 +53,7 @@ func registerCreateVaultCmd(ctx *context.Context, vaultCmd *cobra.Command) {
 				errhandler.HandleUsage(ctx, cmd, "invalid vault name '%s': %v", vaultName, err)
 			}
 
-			if _, found := ctx.Config.Vaults[vaultName]; found {
+			if vault.VaultExists(vaultName) {
 				errhandler.HandleUsage(ctx, cmd, "vault %s already exists", vaultName)
 			}
 		},
@@ -176,7 +174,7 @@ func registerGetVaultCmd(ctx *context.Context, vaultCmd *cobra.Command) {
 		Short:   "Get the details of a vault.",
 		Args:    cobra.MaximumNArgs(1),
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-			return vaultNames(ctx.Config), cobra.ShellCompDirectiveNoFileComp
+			return vaultNames(), cobra.ShellCompDirectiveNoFileComp
 		},
 		PreRun: func(cmd *cobra.Command, args []string) {
 			var vaultName string
@@ -236,12 +234,15 @@ func registerListVaultCmd(ctx *context.Context, vaultCmd *cobra.Command) {
 func listVaultsFunc(ctx *context.Context, cmd *cobra.Command, _ []string) {
 	outputFormat := flags.ValueFor[string](cmd, *flags.OutputFormatFlag, false)
 
-	cfg := ctx.Config
+	names, err := vault.ListVaultNames()
+	if err != nil {
+		errhandler.HandleFatal(ctx, cmd, err)
+	}
 	if TUIEnabled(ctx, cmd) {
-		view := vaultIO.NewVaultListView(ctx.TUIContainer(), maps.Keys(cfg.Vaults))
+		view := vaultIO.NewVaultListView(ctx.TUIContainer(), names)
 		SetView(ctx, cmd, view)
 	} else {
-		vaultIO.PrintVaultList(outputFormat, maps.Keys(cfg.Vaults))
+		vaultIO.PrintVaultList(outputFormat, names)
 	}
 }
 
@@ -250,14 +251,14 @@ func registerRemoveVaultCmd(ctx *context.Context, vaultCmd *cobra.Command) {
 		Use:     "remove NAME",
 		Aliases: []string{"rm", "delete"},
 		Short:   "Remove an existing vault.",
-		Long: "Remove an existing vault by its name. The vault data will remain in it's original location, " +
-			"but the vault will be unlinked from the global configuration.\nNote: You cannot remove the current vault.",
+		Long: "Remove an existing vault by its name. The vault's encrypted secret data remains on disk " +
+			"at its storage path, but its configuration is deleted so flow no longer tracks it.\n" +
+			"Note: You cannot remove the current vault.",
 		Args: cobra.ExactArgs(1),
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-			return vaultNames(ctx.Config), cobra.ShellCompDirectiveNoFileComp
+			return vaultNames(), cobra.ShellCompDirectiveNoFileComp
 		},
-		PreRun: func(cmd *cobra.Command, args []string) { validateVaults(ctx, cmd) },
-		Run:    func(cmd *cobra.Command, args []string) { removeVaultFunc(ctx, cmd, args) },
+		Run: func(cmd *cobra.Command, args []string) { removeVaultFunc(ctx, cmd, args) },
 	}
 	RegisterFlag(ctx, removeCmd, *flags.OutputFormatFlag)
 	RegisterFlag(ctx, removeCmd, *flags.YesFlag)
@@ -299,10 +300,16 @@ func removeVaultFunc(ctx *context.Context, cmd *cobra.Command, args []string) {
 	if userConfig.CurrentVault != nil && vaultName == *userConfig.CurrentVault {
 		errhandler.HandleUsage(ctx, cmd, "cannot remove the current vault")
 	}
-	if _, found := userConfig.Vaults[vaultName]; !found {
+	if !vault.VaultExists(vaultName) {
 		errhandler.HandleFatal(ctx, cmd, fmt.Errorf("vault %s was not found", vaultName))
 	}
 
+	// Delete the vault's config file (the source of truth). Encrypted secret data at the
+	// vault's storage path is intentionally preserved.
+	if err := vault.RemoveVaultConfig(vaultName); err != nil {
+		errhandler.HandleFatal(ctx, cmd, err)
+	}
+	// Also drop the legacy config-map entry if present, keeping the two in sync.
 	delete(userConfig.Vaults, vaultName)
 	if err := filesystem.WriteConfig(userConfig); err != nil {
 		errhandler.HandleFatal(ctx, cmd, err)
@@ -320,16 +327,14 @@ func registerSwitchVaultCmd(ctx *context.Context, vaultCmd *cobra.Command) {
 		Short:   "Switch the active vault.",
 		Args:    cobra.ExactArgs(1),
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-			return vaultNames(ctx.Config), cobra.ShellCompDirectiveNoFileComp
+			return vaultNames(), cobra.ShellCompDirectiveNoFileComp
 		},
 		PreRun: func(cmd *cobra.Command, args []string) {
 			vaultName := args[0]
-			reservedName := vaultName == vault.DemoVaultReservedName
-			if reservedName {
+			if vaultName == vault.DemoVaultReservedName {
 				return
 			}
-			validateVaults(ctx, cmd)
-			if _, found := ctx.Config.Vaults[vaultName]; !found {
+			if !vault.VaultExists(vaultName) {
 				errhandler.HandleFatal(ctx, cmd, fmt.Errorf("vault %s not found", vaultName))
 			}
 		},
@@ -361,10 +366,9 @@ func registerEditVaultCmd(ctx *context.Context, vaultCmd *cobra.Command) {
 			"Note: You cannot change the vault type after creation.",
 		Args: cobra.ExactArgs(1),
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-			return vaultNames(ctx.Config), cobra.ShellCompDirectiveNoFileComp
+			return vaultNames(), cobra.ShellCompDirectiveNoFileComp
 		},
 		PreRun: func(cmd *cobra.Command, args []string) {
-			validateVaults(ctx, cmd)
 			vaultName := args[0]
 			if vaultName == vault.DemoVaultReservedName {
 				errhandler.HandleUsage(ctx, cmd, "edit is unsupported for the reserved vault")
@@ -372,8 +376,7 @@ func registerEditVaultCmd(ctx *context.Context, vaultCmd *cobra.Command) {
 				errhandler.HandleUsage(ctx, cmd, "invalid vault name '%s': %v", vaultName, err)
 			}
 
-			userConfig := ctx.Config
-			if _, found := userConfig.Vaults[vaultName]; !found {
+			if !vault.VaultExists(vaultName) {
 				errhandler.HandleFatal(ctx, cmd, fmt.Errorf("vault %s not found", vaultName))
 			}
 		},
@@ -464,21 +467,13 @@ func editVaultFunc(ctx *context.Context, cmd *cobra.Command, args []string) {
 	)
 }
 
-func vaultNames(cfg *config.Config) []string {
+func vaultNames() []string {
 	names := []string{vault.DemoVaultReservedName}
-	if cfg == nil || cfg.Vaults == nil {
-		return nil
+	discovered, err := vault.ListVaultNames()
+	if err != nil {
+		return names
 	}
-	for name := range cfg.Vaults {
-		names = append(names, name)
-	}
-	return names
-}
-
-func validateVaults(ctx *context.Context, cmd *cobra.Command) {
-	if ctx.Config == nil || ctx.Config.Vaults == nil {
-		errhandler.HandleUsage(ctx, cmd, "no vaults configured")
-	}
+	return append(names, discovered...)
 }
 
 const (

--- a/docs/cli/flow_vault_remove.md
+++ b/docs/cli/flow_vault_remove.md
@@ -4,7 +4,7 @@ Remove an existing vault.
 
 ### Synopsis
 
-Remove an existing vault by its name. The vault data will remain in it's original location, but the vault will be unlinked from the global configuration.
+Remove an existing vault by its name. The vault's encrypted secret data remains on disk at its storage path, but its configuration is deleted so flow no longer tracks it.
 Note: You cannot remove the current vault.
 
 ```

--- a/docs/guides/secrets.md
+++ b/docs/guides/secrets.md
@@ -313,7 +313,8 @@ flow vault get my-vault
 # Edit vault settings
 flow vault edit my-vault --key-env NEW_KEY_VAR
 
-# Remove vault (data remains, just unlinks)
+# Remove a vault's configuration. The encrypted secret data remains on disk at its
+# storage path; only the vault config flow tracks is deleted.
 flow vault remove old-vault
 ```
 

--- a/docs/public/schemas/config_schema.json
+++ b/docs/public/schemas/config_schema.json
@@ -90,7 +90,7 @@
       "default": ""
     },
     "currentVault": {
-      "description": "The name of the current vault. This should match a key in the `vaults` map.",
+      "description": "The name of the currently active vault.",
       "type": "string"
     },
     "currentWorkspace": {
@@ -138,7 +138,7 @@
       "default": false
     },
     "vaults": {
-      "description": "A map of vault names to their paths. The path should be a valid absolute path to the vault file created by flow.",
+      "description": "A legacy map of vault names to their storage paths, retained for backwards compatibility.\nThe authoritative list of vaults is discovered from the vault configuration directory managed\nby flow; this map is no longer required to reference or switch vaults.\n",
       "type": "object",
       "additionalProperties": {
         "type": "string"

--- a/docs/types/config.md
+++ b/docs/types/config.md
@@ -29,7 +29,7 @@ Alternatively, a custom path can be set using the `FLOW_CONFIG_PATH` environment
 | ----- | ----------- | ---- | ------- | :--------: |
 | `colorOverride` | Override the default color palette for the interactive UI. This can be used to customize the colors of the UI.  | [ColorPalette](#colorpalette) |  |  |
 | `currentNamespace` | The name of the current namespace.  Namespaces are used to reference executables in the CLI using the format `workspace:namespace/name`. If the namespace is not set, only executables defined without a namespace will be discovered.  | `string` |  |  |
-| `currentVault` | The name of the current vault. This should match a key in the `vaults` map. | `string` |  |  |
+| `currentVault` | The name of the currently active vault. | `string` |  |  |
 | `currentWorkspace` | The name of the current workspace. This should match a key in the `workspaces` or `remoteWorkspaces` map. | `string` |  |  |
 | `defaultLogMode` | The default log mode to use when running executables. This can either be `hidden`, `json`, `logfmt` or `text`  `hidden` will not display any logs. `json` will display logs in JSON format. `logfmt` will display logs with a log level, timestamp, and message. `text` will just display the log message.  | `string` | logfmt |  |
 | `defaultTimeout` | The default timeout to use when running executables. This should be a valid duration string.  | `string` | 30m |  |
@@ -37,7 +37,7 @@ Alternatively, a custom path can be set using the `FLOW_CONFIG_PATH` environment
 | `templates` | A map of flowfile template names to their paths. | `map` (`string` -> `string`) | map[] |  |
 | `theme` | The theme of the interactive UI. | `string` | default |  |
 | `updateCheck` | Whether to check for CLI updates in the background. When enabled, flow will periodically check GitHub for a newer version and display a notice if one is available after each command. Set `FLOW_NO_UPDATE_CHECK=1` to suppress checks regardless of this setting.  | `boolean` | false |  |
-| `vaults` | A map of vault names to their paths. The path should be a valid absolute path to the vault file created by flow. | `map` (`string` -> `string`) |  |  |
+| `vaults` | A legacy map of vault names to their storage paths, retained for backwards compatibility. The authoritative list of vaults is discovered from the vault configuration directory managed by flow; this map is no longer required to reference or switch vaults.  | `map` (`string` -> `string`) |  |  |
 | `workspaceMode` | The mode of the workspace. This can be either `fixed` or `dynamic`. In `fixed` mode, the current workspace used at runtime is always the one set in the currentWorkspace config field. In `dynamic` mode, the current workspace used at runtime is determined by the current directory. If the current directory is within a workspace, that workspace is used.  | `string` | dynamic |  |
 | `workspaces` | Map of workspace names to their paths. The path should be a valid absolute path to the workspace directory.  | `map` (`string` -> `string`) |  |  |
 

--- a/internal/validation/config_schema.json
+++ b/internal/validation/config_schema.json
@@ -90,7 +90,7 @@
       "default": ""
     },
     "currentVault": {
-      "description": "The name of the current vault. This should match a key in the `vaults` map.",
+      "description": "The name of the currently active vault.",
       "type": "string"
     },
     "currentWorkspace": {
@@ -138,7 +138,7 @@
       "default": false
     },
     "vaults": {
-      "description": "A map of vault names to their paths. The path should be a valid absolute path to the vault file created by flow.",
+      "description": "A legacy map of vault names to their storage paths, retained for backwards compatibility.\nThe authoritative list of vaults is discovered from the vault configuration directory managed\nby flow; this map is no longer required to reference or switch vaults.\n",
       "type": "object",
       "additionalProperties": {
         "type": "string"

--- a/internal/vault/secret.go
+++ b/internal/vault/secret.go
@@ -37,6 +37,8 @@ type Secret interface {
 	Ref() SecretRef
 	AsPlaintext() Secret
 	AsObfuscatedText() Secret
+	// IsPlaintext reports whether the secret is currently in plaintext (unobfuscated) mode.
+	IsPlaintext() bool
 }
 
 type SecretValue = vault.SecretValue
@@ -88,6 +90,10 @@ func (s *secret) AsPlaintext() Secret {
 func (s *secret) AsObfuscatedText() Secret {
 	s.plaintext = false
 	return s
+}
+
+func (s *secret) IsPlaintext() bool {
+	return s.plaintext
 }
 
 func (s *secret) YAML() (string, error) {
@@ -152,16 +158,7 @@ func RefToParts(ref SecretRef) (vaultName, key string, err error) {
 }
 
 func toEnrichedSecret(s Secret) enrichedSecret {
-	valueStr := s.String() // Default to obfuscated
-	if s.AsPlaintext() != nil {
-		valueStr = s.PlainTextString()
-	}
-
-	return enrichedSecret{
-		Vault: s.Ref().Vault(),
-		Key:   s.Ref().Key(),
-		Value: valueStr,
-	}
+	return toEnrichedSecretWithMode(s, s.IsPlaintext())
 }
 
 // toEnrichedSecretWithMode allows explicit control over plaintext vs obfuscated
@@ -208,22 +205,22 @@ type enrichedSecretList struct {
 
 func (l SecretList) AsPlaintext() SecretList {
 	result := make(SecretList, 0, len(l))
-	for i, s := range l {
+	for _, s := range l {
 		if s == nil {
 			continue
 		}
-		result[i] = s.AsPlaintext()
+		result = append(result, s.AsPlaintext())
 	}
 	return result
 }
 
 func (l SecretList) AsObfuscatedText() SecretList {
-	result := make(SecretList, len(l))
-	for i, s := range l {
+	result := make(SecretList, 0, len(l))
+	for _, s := range l {
 		if s == nil {
 			continue
 		}
-		result[i] = s.AsObfuscatedText()
+		result = append(result, s.AsObfuscatedText())
 	}
 	return result
 }

--- a/internal/vault/secret_test.go
+++ b/internal/vault/secret_test.go
@@ -1,0 +1,106 @@
+package vault_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/flowexec/flow/v2/internal/vault"
+)
+
+const testSecretValue = "hunter2-super-secret"
+
+func newTestSecret(t *testing.T, key, value string) vault.Secret {
+	t.Helper()
+	s, err := vault.NewSecret("testvault", key, vault.NewSecretValue([]byte(value)))
+	if err != nil {
+		t.Fatalf("NewSecret(%q) returned error: %v", key, err)
+	}
+	return s
+}
+
+// A secret list serialized in obfuscated mode must never leak the plaintext value.
+// This guards against a regression where serialization always emitted plaintext.
+func TestSecretList_YAML_ObfuscatedByDefault(t *testing.T) {
+	list := vault.SecretList{newTestSecret(t, "token", testSecretValue)}.AsObfuscatedText()
+
+	out, err := list.YAML()
+	if err != nil {
+		t.Fatalf("YAML() error: %v", err)
+	}
+	if strings.Contains(out, testSecretValue) {
+		t.Fatalf("obfuscated YAML leaked the plaintext secret value:\n%s", out)
+	}
+	if !strings.Contains(out, "********") {
+		t.Fatalf("obfuscated YAML did not contain the masked value:\n%s", out)
+	}
+}
+
+func TestSecretList_JSON_ObfuscatedByDefault(t *testing.T) {
+	list := vault.SecretList{newTestSecret(t, "token", testSecretValue)}.AsObfuscatedText()
+
+	out, err := list.JSON()
+	if err != nil {
+		t.Fatalf("JSON() error: %v", err)
+	}
+	if strings.Contains(out, testSecretValue) {
+		t.Fatalf("obfuscated JSON leaked the plaintext secret value:\n%s", out)
+	}
+}
+
+func TestSecretList_YAML_PlaintextWhenRequested(t *testing.T) {
+	list := vault.SecretList{newTestSecret(t, "token", testSecretValue)}.AsPlaintext()
+
+	out, err := list.YAML()
+	if err != nil {
+		t.Fatalf("YAML() error: %v", err)
+	}
+	if !strings.Contains(out, testSecretValue) {
+		t.Fatalf("plaintext YAML did not contain the secret value:\n%s", out)
+	}
+}
+
+// AsPlaintext previously allocated a zero-length slice then indexed into it, panicking on
+// any non-empty list. Verify it converts every element without panicking.
+func TestSecretList_AsPlaintext_NoPanic(t *testing.T) {
+	list := vault.SecretList{
+		newTestSecret(t, "k1", "a"),
+		newTestSecret(t, "k2", "b"),
+		newTestSecret(t, "k3", "c"),
+	}
+
+	result := list.AsPlaintext()
+	if len(result) != 3 {
+		t.Fatalf("AsPlaintext() returned %d secrets, want 3", len(result))
+	}
+	for i, s := range result {
+		if !s.IsPlaintext() {
+			t.Errorf("result[%d] is not in plaintext mode", i)
+		}
+	}
+}
+
+func TestSecretList_AsObfuscatedText_NoPanic(t *testing.T) {
+	list := vault.SecretList{
+		newTestSecret(t, "k1", "a"),
+		newTestSecret(t, "k2", "b"),
+	}
+	if got := len(list.AsObfuscatedText()); got != 2 {
+		t.Fatalf("AsObfuscatedText() returned %d secrets, want 2", got)
+	}
+}
+
+func TestValidateIdentifier(t *testing.T) {
+	valid := []string{"myvault", "my_vault", "my-vault", "abc123", "A1_b-2"}
+	for _, name := range valid {
+		if err := vault.ValidateIdentifier(name); err != nil {
+			t.Errorf("ValidateIdentifier(%q) = %v, want nil", name, err)
+		}
+	}
+
+	invalid := []string{"", "../etc", "a/b", "a.b", "a b", "..", "vault/../x", "name.json"}
+	for _, name := range invalid {
+		if err := vault.ValidateIdentifier(name); err == nil {
+			t.Errorf("ValidateIdentifier(%q) = nil, want error", name)
+		}
+	}
+}

--- a/internal/vault/vault.go
+++ b/internal/vault/vault.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/flowexec/vault"
@@ -180,6 +181,12 @@ func NewExternalVault(providerConfigFile string) (*CreateResult, error) {
 		return nil, fmt.Errorf("failed to load vault config: %w", err)
 	}
 
+	// The ID comes from an external file and is used to derive the stored config path,
+	// so validate it before it reaches the filesystem.
+	if err := ValidateIdentifier(cfg.ID); err != nil {
+		return nil, fmt.Errorf("invalid vault name %q in config: %w", cfg.ID, err)
+	}
+
 	v, _, err := vault.New(cfg.ID, vault.WithExternalConfig(cfg.External))
 	if err != nil {
 		return nil, err
@@ -198,6 +205,12 @@ func VaultFromName(name string) (*VaultConfig, Vault, error) {
 		return nil, nil, fmt.Errorf("vault name cannot be empty")
 	} else if strings.ToLower(name) == DemoVaultReservedName {
 		return newDemoVaultConfig(), newDemoVault(), nil
+	}
+
+	// Validate before deriving a filesystem path so a crafted name (e.g. containing
+	// path separators or "..") cannot be used to read arbitrary files as vault configs.
+	if err := ValidateIdentifier(name); err != nil {
+		return nil, nil, fmt.Errorf("invalid vault name: %w", err)
 	}
 
 	cfgPath := ConfigFilePath(name)
@@ -232,12 +245,64 @@ func CacheDirectory(subPath string) string {
 	return filepath.Join(filesystem.CachedDataDirPath(), v2CacheDataDir, subPath)
 }
 
+// configsDir is the directory holding per-vault configuration files. It is the source
+// of truth for which vaults exist: a vault is usable iff its <name>.json lives here.
+func configsDir() string {
+	return CacheDirectory("configs")
+}
+
 func ConfigFilePath(vaultName string) string {
-	return filepath.Join(
-		filesystem.CachedDataDirPath(),
-		v2CacheDataDir,
-		fmt.Sprintf("configs/%s.json", vaultName),
-	)
+	return filepath.Join(configsDir(), fmt.Sprintf("%s.json", vaultName))
+}
+
+// ListVaultNames returns the names of all configured vaults by reading the vault config
+// directory — the same source VaultFromName loads from — so listings never drift from
+// what is actually openable. The reserved demo vault is not included (it has no config
+// file); callers that want it should add it explicitly. Names are sorted.
+func ListVaultNames() ([]string, error) {
+	entries, err := os.ReadDir(configsDir())
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("unable to read vault config directory: %w", err)
+	}
+
+	names := make([]string, 0, len(entries))
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
+			continue
+		}
+		names = append(names, strings.TrimSuffix(e.Name(), ".json"))
+	}
+	sort.Strings(names)
+	return names, nil
+}
+
+// VaultExists reports whether a vault with the given name is available — either the
+// reserved demo vault or a vault whose config file exists on disk.
+func VaultExists(name string) bool {
+	if strings.EqualFold(name, DemoVaultReservedName) {
+		return true
+	}
+	if ValidateIdentifier(name) != nil {
+		return false
+	}
+	_, err := os.Stat(ConfigFilePath(name))
+	return err == nil
+}
+
+// RemoveVaultConfig deletes a vault's configuration file. The vault's encrypted secret
+// data, stored separately at the vault's storage path, is left untouched. Removing a
+// non-existent config is not an error.
+func RemoveVaultConfig(name string) error {
+	if err := ValidateIdentifier(name); err != nil {
+		return fmt.Errorf("invalid vault name: %w", err)
+	}
+	if err := os.Remove(ConfigFilePath(name)); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("unable to remove vault config: %w", err)
+	}
+	return nil
 }
 
 func writeKeyToFile(key, filePath string) error {

--- a/internal/vault/vault_test.go
+++ b/internal/vault/vault_test.go
@@ -1,0 +1,129 @@
+package vault_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/flowexec/flow/v2/internal/vault"
+	"github.com/flowexec/flow/v2/pkg/filesystem"
+)
+
+// A crafted vault name must be rejected before it is turned into a filesystem path,
+// so it cannot be used to read arbitrary files as vault configs.
+func TestVaultFromName_RejectsTraversal(t *testing.T) {
+	for _, name := range []string{"../../etc/passwd", "a/b", "..", "with space"} {
+		_, _, err := vault.VaultFromName(name)
+		if err == nil {
+			t.Errorf("VaultFromName(%q) = nil error, want rejection", name)
+			continue
+		}
+		if !strings.Contains(err.Error(), "invalid vault name") {
+			t.Errorf("VaultFromName(%q) error = %v, want invalid-name rejection", name, err)
+		}
+	}
+}
+
+func TestVaultFromName_EmptyAndDemo(t *testing.T) {
+	if _, _, err := vault.VaultFromName(""); err == nil {
+		t.Error("VaultFromName(\"\") = nil error, want error")
+	}
+
+	cfg, v, err := vault.VaultFromName(vault.DemoVaultReservedName)
+	if err != nil {
+		t.Fatalf("VaultFromName(demo) error: %v", err)
+	}
+	if cfg == nil || v == nil {
+		t.Fatal("VaultFromName(demo) returned nil config or provider")
+	}
+}
+
+func TestListVaultNames_ReadsConfigsDir(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv(filesystem.FlowCacheDirEnvVar, tmp)
+
+	configs := vault.CacheDirectory("configs")
+	if err := os.MkdirAll(configs, 0750); err != nil {
+		t.Fatalf("mkdir configs: %v", err)
+	}
+	write := func(name string) {
+		if err := os.WriteFile(filepath.Join(configs, name), []byte("{}"), 0600); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+	write("alpha.json")
+	write("beta.json")
+	write("notes.txt") // non-config file, must be ignored
+
+	names, err := vault.ListVaultNames()
+	if err != nil {
+		t.Fatalf("ListVaultNames() error: %v", err)
+	}
+	if len(names) != 2 || names[0] != "alpha" || names[1] != "beta" {
+		t.Fatalf("ListVaultNames() = %v, want [alpha beta] sorted", names)
+	}
+}
+
+func TestListVaultNames_MissingDir(t *testing.T) {
+	t.Setenv(filesystem.FlowCacheDirEnvVar, t.TempDir())
+	names, err := vault.ListVaultNames()
+	if err != nil {
+		t.Fatalf("ListVaultNames() on missing dir error: %v", err)
+	}
+	if len(names) != 0 {
+		t.Fatalf("ListVaultNames() on missing dir = %v, want empty", names)
+	}
+}
+
+func TestVaultExists(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv(filesystem.FlowCacheDirEnvVar, tmp)
+	configs := vault.CacheDirectory("configs")
+	if err := os.MkdirAll(configs, 0750); err != nil {
+		t.Fatalf("mkdir configs: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(configs, "alpha.json"), []byte("{}"), 0600); err != nil {
+		t.Fatalf("write alpha: %v", err)
+	}
+
+	cases := map[string]bool{
+		"alpha":                     true,
+		vault.DemoVaultReservedName: true,
+		"missing":                   false,
+		"../escape":                 false,
+		"a/b":                       false,
+	}
+	for name, want := range cases {
+		if got := vault.VaultExists(name); got != want {
+			t.Errorf("VaultExists(%q) = %v, want %v", name, got, want)
+		}
+	}
+}
+
+func TestRemoveVaultConfig(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv(filesystem.FlowCacheDirEnvVar, tmp)
+	configs := vault.CacheDirectory("configs")
+	if err := os.MkdirAll(configs, 0750); err != nil {
+		t.Fatalf("mkdir configs: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(configs, "alpha.json"), []byte("{}"), 0600); err != nil {
+		t.Fatalf("write alpha: %v", err)
+	}
+
+	if err := vault.RemoveVaultConfig("alpha"); err != nil {
+		t.Fatalf("RemoveVaultConfig(alpha) error: %v", err)
+	}
+	if vault.VaultExists("alpha") {
+		t.Error("alpha still exists after RemoveVaultConfig")
+	}
+	// Removing a non-existent vault is not an error.
+	if err := vault.RemoveVaultConfig("alpha"); err != nil {
+		t.Errorf("RemoveVaultConfig on missing vault error: %v", err)
+	}
+	// Invalid names are rejected rather than acted on.
+	if err := vault.RemoveVaultConfig("../escape"); err == nil {
+		t.Error("RemoveVaultConfig(../escape) = nil, want error")
+	}
+}

--- a/types/config/config.gen.go
+++ b/types/config/config.gen.go
@@ -82,7 +82,7 @@ type Config struct {
 	//
 	CurrentNamespace string `json:"currentNamespace,omitempty" yaml:"currentNamespace,omitempty" mapstructure:"currentNamespace,omitempty"`
 
-	// The name of the current vault. This should match a key in the `vaults` map.
+	// The name of the currently active vault.
 	CurrentVault *string `json:"currentVault,omitempty" yaml:"currentVault,omitempty" mapstructure:"currentVault,omitempty"`
 
 	// The name of the current workspace. This should match a key in the `workspaces`
@@ -120,8 +120,12 @@ type Config struct {
 	//
 	UpdateCheck bool `json:"updateCheck,omitempty" yaml:"updateCheck,omitempty" mapstructure:"updateCheck,omitempty"`
 
-	// A map of vault names to their paths. The path should be a valid absolute path
-	// to the vault file created by flow.
+	// A legacy map of vault names to their storage paths, retained for backwards
+	// compatibility.
+	// The authoritative list of vaults is discovered from the vault configuration
+	// directory managed
+	// by flow; this map is no longer required to reference or switch vaults.
+	//
 	Vaults ConfigVaults `json:"vaults,omitempty" yaml:"vaults,omitempty" mapstructure:"vaults,omitempty"`
 
 	// The mode of the workspace. This can be either `fixed` or `dynamic`.
@@ -151,8 +155,11 @@ const ConfigThemeEverforest ConfigTheme = "everforest"
 const ConfigThemeLight ConfigTheme = "light"
 const ConfigThemeTokyoNight ConfigTheme = "tokyo-night"
 
-// A map of vault names to their paths. The path should be a valid absolute path to
-// the vault file created by flow.
+// A legacy map of vault names to their storage paths, retained for backwards
+// compatibility.
+// The authoritative list of vaults is discovered from the vault configuration
+// directory managed
+// by flow; this map is no longer required to reference or switch vaults.
 type ConfigVaults map[string]string
 
 type ConfigWorkspaceMode string

--- a/types/config/schema.yaml
+++ b/types/config/schema.yaml
@@ -150,10 +150,13 @@ properties:
     type: object
     additionalProperties:
       type: string
-    description: A map of vault names to their paths. The path should be a valid absolute path to the vault file created by flow.
+    description: |
+      A legacy map of vault names to their storage paths, retained for backwards compatibility.
+      The authoritative list of vaults is discovered from the vault configuration directory managed
+      by flow; this map is no longer required to reference or switch vaults.
   currentVault:
     type: string
-    description: The name of the current vault. This should match a key in the `vaults` map.
+    description: The name of the currently active vault.
   updateCheck:
     type: boolean
     description: |


### PR DESCRIPTION
## Summary

- **Plaintext leak in `secret list -o yaml/json`.** `toEnrichedSecret` used `if s.AsPlaintext() != nil`, which is *always* true (and mutated the secret to plaintext as a side effect), so obfuscated serialization emitted secret values in the clear. Serialization now respects the secret's mode via a new `IsPlaintext()` on the `Secret` interface. `secret get` was unaffected.
- **Path-traversal hardening.** `VaultFromName` (the runtime access path) and external-config loading built `configs/<name>.json` without validating `<name>`. A crafted name (path separators / `..`) could point the loader at arbitrary `.json` files. Both now validate the identifier before touching the filesystem.
- **Panic in `SecretList.AsPlaintext()`.** It allocated `make(SecretList, 0, len(l))` then assigned by index, panicking on any non-empty vault (e.g. `secret list --as-plain-text -o yaml`). Rewritten with `append`; `AsObfuscatedText` aligned to the same pattern.

**Note:** `vault list`/`switch`/`get`/`edit`/`remove` operated on the legacy `Config.Vaults` map, while actual vault access reads the vault **config directory**. These could diverge (a config present on disk but missing from the map, or vice-versa, would make `list` disagree with what's openable). All of these commands now treat the config directory as the source of truth (`ListVaultNames`/`VaultExists`).

**Behavior change:** `vault remove` now deletes the vault's **config file** (previously it only unlinked the map entry). The encrypted secret **data** at the vault's storage path is preserved — only the config flow tracks is removed. This is required for a removed vault to actually disappear from the discovered listing, and the docs/help text are updated to match. The `Config.Vaults` map is still written/cleaned on create/remove for backwards compatibility, and its schema description now notes it's legacy.