### PR TITLE
build(deps): bump tuikit to v0.4.1 for logger data-race fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/atotto/clipboard v0.1.4
 	github.com/charmbracelet/colorprofile v0.4.3
 	github.com/charmbracelet/x/exp/teatest/v2 v2.0.0-20260406091427-a791e22d5143
-	github.com/flowexec/tuikit v0.4.0
+	github.com/flowexec/tuikit v0.4.1
 	github.com/flowexec/vault v0.2.1
 	github.com/gen2brain/beeep v0.11.2
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -86,8 +86,8 @@ github.com/esiqveland/notify v0.13.3 h1:QCMw6o1n+6rl+oLUfg8P1IIDSFsDEb2WlXvVvIJb
 github.com/esiqveland/notify v0.13.3/go.mod h1:hesw/IRYTO0x99u1JPweAl4+5mwXJibQVUcP0Iu5ORE=
 github.com/expr-lang/expr v1.17.7 h1:Q0xY/e/2aCIp8g9s/LGvMDCC5PxYlvHgDZRQ4y16JX8=
 github.com/expr-lang/expr v1.17.7/go.mod h1:8/vRC7+7HBzESEqt5kKpYXxrxkr31SaO8r40VO/1IT4=
-github.com/flowexec/tuikit v0.4.0 h1:AUlOmQSCICHg6fz1jXxhxDz5dPKpuH2O0Jf7v4uN8Hk=
-github.com/flowexec/tuikit v0.4.0/go.mod h1:NmuWfE/77Nj2qoyiH/4x1b5Ak1JOpL6HqpPEai38UHQ=
+github.com/flowexec/tuikit v0.4.1 h1:c8qJtB0e8k8VnYnerwai/f4Gg8kkJTLE3fjsMRu619U=
+github.com/flowexec/tuikit v0.4.1/go.mod h1:NmuWfE/77Nj2qoyiH/4x1b5Ak1JOpL6HqpPEai38UHQ=
 github.com/flowexec/vault v0.2.1 h1:IYII6iXhhzUc4o0arJVH8281so67L9V8HY8ary/kTps=
 github.com/flowexec/vault v0.2.1/go.mod h1:6JHONK+fTf8Zn7bOwejzbKTWuIh1BYHxgAwBc/XPXeY=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=


### PR DESCRIPTION
## Summary

Bumps tuikit `v0.4.0` → `v0.4.1`, which fixes the logger data race at the source (flowexec/tuikit#112) instead of working around it in flow.

The race was between a command's stdout and stderr streams (copied by os/exec in separate goroutines) both flipping `StandardLogger`'s shared `mode` field. tuikit v0.4.1:
- guards the `mode` field with a mutex,
- serializes the writers' flip/render/restore sequence, and
- fixes `StdOutWriter` never restoring the mode after a flip.

Since the fix lives in the dependency, no client-side change is needed here beyond the version bump — this PR previously carried a `syncWriter` workaround, now removed in favor of the upstream fix.

## Testing

- `flow validate` passes (generate → lint → unit + e2e → schemas).
- Race coverage lives upstream in tuikit's `output_race_test.go`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)