### PR TITLE
fix(vault): open pre-v0.4.0 external vaults

### DIFF
--- a/internal/io/vault/output.go
+++ b/internal/io/vault/output.go
@@ -38,7 +38,8 @@ func PrintVaultList(format string, vaultNames []string) {
 	for _, name := range vaultNames {
 		vault, err := vaultFromName(name)
 		if err != nil {
-			logger.Log().Fatalf("Vault error %s - %v", name, err)
+			logger.Log().Warnf("vault %s could not be opened - %v", name, err)
+			vault = unopenableVault(name, err)
 		}
 		vaults.Vaults = append(vaults.Vaults, vault)
 	}

--- a/internal/io/vault/view.go
+++ b/internal/io/vault/view.go
@@ -21,8 +21,18 @@ type vaultEntity struct {
 	Name string `json:"name" yaml:"name"`
 	Path string `json:"path" yaml:"path"`
 	Type string `json:"type" yaml:"type"`
+	// Error is set when the vault could not be opened. It is listed anyway, so
+	// one unusable vault does not hide every other one.
+	Error string `json:"error,omitempty" yaml:"error,omitempty"`
 
 	Data map[string]interface{} `json:"data" yaml:"data"`
+}
+
+// unopenableVault is the placeholder for a vault whose config loads but whose
+// provider will not open -- a missing key, a revoked identity, a config written
+// by an older version.
+func unopenableVault(name string, err error) *vaultEntity {
+	return &vaultEntity{Name: name, Type: "unknown", Error: err.Error(), Data: map[string]interface{}{}}
 }
 
 func (v *vaultEntity) YAML() (string, error) {
@@ -115,10 +125,7 @@ func NewVaultListView(
 	for _, name := range vaultNames {
 		v, err := vaultFromName(name)
 		if err != nil || v == nil {
-			return views.NewErrorView(
-				fmt.Errorf("vault '%s' error: %w", name, err),
-				container.RenderState().Theme,
-			)
+			v = unopenableVault(name, err)
 		}
 		vaults = append(vaults, v)
 	}

--- a/internal/vault/vault.go
+++ b/internal/vault/vault.go
@@ -210,13 +210,7 @@ func NewExternalVault(providerConfigFile string) (*CreateResult, error) {
 		return nil, fmt.Errorf("invalid vault name %q in config: %w", cfg.ID, err)
 	}
 
-	// An external vault keeps a registry of the links it holds. A config authored
-	// elsewhere -- rendered from a preset, or written by hand -- has no business
-	// knowing where flow keeps vault state, so it arrives without a storage path
-	// and flow supplies the same location every other provider uses.
-	if cfg.External != nil && cfg.External.StoragePath == "" {
-		cfg.External.StoragePath = CacheDirectory(cfg.ID)
-	}
+	applyExternalDefaults(&cfg)
 
 	v, _, err := vault.New(cfg.ID, vault.WithExternalConfig(cfg.External))
 	if err != nil {
@@ -249,6 +243,8 @@ func VaultFromName(name string) (*VaultConfig, Vault, error) {
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to load vault config: %w", err)
 	}
+
+	applyExternalDefaults(&cfg)
 
 	switch cfg.Type {
 	case vault.ProviderTypeAge:
@@ -359,4 +355,13 @@ func writeKeyToFile(key, filePath string) error {
 	logger.Log().Infof("Key written to file: %s", filePath)
 
 	return nil
+}
+
+// applyExternalDefaults fills in settings a config authored elsewhere cannot
+// know. External vaults created before the link registry existed have no
+// storage path, so this has to run when opening a vault as well as creating one.
+func applyExternalDefaults(cfg *VaultConfig) {
+	if cfg.External != nil && cfg.External.StoragePath == "" {
+		cfg.External.StoragePath = CacheDirectory(cfg.ID)
+	}
 }


### PR DESCRIPTION
Follow-up to #419. Two bugs that together made the desktop's vault dropdown come up empty and disabled.

## An external vault created before v0.4.0 cannot be opened

Those configs have no `storage_path`, and `NewExternalVaultProvider` now requires one. The default was applied when *creating* a vault but not when *opening* one, so every pre-existing external vault broke on upgrade:

```
$ flow vault list --output json
ERR Vault error Klipster - invalid configuration: external vault "Klipster" needs a storage path for its link registry
(no output, non-zero exit)
```

`applyExternalDefaults` now runs on both paths.

## One unopenable vault hid every other one

`PrintVaultList` called `Fatalf` on the first vault it could not open, so a single bad vault produced no output at all rather than one bad row. The TUI list view did the same via `NewErrorView`.

A vault that will not open is now listed with an `error` field, and the rest still load. This matters beyond the bug above — a missing key env var or a revoked age identity would have blanked the whole list the same way.

## Verified

Against a real config carrying a pre-v0.4.0 external vault: it opens cleanly once the default applies, and all four vaults list.

Against an isolated config with a vault broken in a way defaults *cannot* repair: it shows as `type=unknown` with its error while the healthy vault still lists.

```
broken     type=unknown      error=invalid configuration: a get command template is required...
healthy    type=unencrypted  error=
```

`0 issues` from golangci-lint v2.5.0; tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)