### PR TITLE
feat(runner): provenance env vars as first class attributions

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -54,5 +54,9 @@
       "Read(./.env)",
       "Read(./.env.*)"
     ]
+  },
+  "env": {
+    "FLOW_RUN_CLIENT": "claude-code",
+    "FLOW_RUN_SESSION": "${CLAUDE_CODE_SESSION_ID}"
   }
 }

--- a/cmd/internal/exec.go
+++ b/cmd/internal/exec.go
@@ -702,15 +702,15 @@ type provenance struct {
 // runProvenanceFromEnv resolves run provenance from environment variables set by the caller
 // (e.g. the MCP server). Source defaults to "cli".
 func runProvenanceFromEnv() provenance {
-	source := os.Getenv(store.RunSourceEnv)
+	source := store.RunEnvValue(store.RunSourceEnv)
 	if source == "" {
 		source = store.RunSourceCLI
 	}
 	wd, _ := os.Getwd()
 	return provenance{
 		source:  source,
-		client:  os.Getenv(store.RunClientEnv),
-		session: os.Getenv(store.RunSessionEnv),
+		client:  store.RunEnvValue(store.RunClientEnv),
+		session: store.RunEnvValue(store.RunSessionEnv),
 		dir:     wd,
 	}
 }

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -73,6 +73,7 @@ export default defineConfig({
               items: [
                 { text: 'Interactive UI', link: '/guides/interactive' },
                 { text: 'AI Tools', link: '/guides/ai-tools' },
+                { text: 'Run Provenance', link: '/guides/run-provenance' },
                 { text: 'Integrations', link: '/guides/integrations' },
               ]
             },

--- a/docs/guides/run-provenance.md
+++ b/docs/guides/run-provenance.md
@@ -1,0 +1,192 @@
+---
+title: Run Provenance
+---
+
+# Run Provenance
+
+Every execution flow records answers *what ran*. Provenance answers **who ran it** — a terminal,
+a GUI, or an AI assistant, and which one.
+
+This page is the contract for setting it. For reading it back, see
+[History & Logs](execution-history.md).
+
+## What gets recorded
+
+| Field | Meaning |
+|---|---|
+| `source` | How the run reached flow — `cli`, `desktop`, or `mcp` |
+| `clientName` | Who drove it — e.g. `claude-code`, `cursor` |
+| `sessionId` | What it groups with, so one assistant's related runs stay together |
+| `workingDir` | Where it executed — the directory, not just the workspace |
+
+`source` is compared as a plain string throughout, so the set is open. The three values above
+are what flow itself produces; anything embedding flow can record its own without waiting for
+a release.
+
+## MCP runs: automatic
+
+Nothing to configure. When an assistant runs something through the
+[MCP server](ai-tools.md) — a named `execute`, a `run_command`, or a `run_executable` — the
+server tags it before handing off to the CLI:
+
+```shell
+flow logs --source mcp --limit 1 -o json
+```
+```json
+{
+  "ref": "exec myproject/adhoc-run-tests",
+  "source": "mcp",
+  "clientName": "claude-code",
+  "sessionId": "4ce5bfea-7ada-4b20-b59e-bcc0df500181",
+  "command": "go test ./...",
+  "label": "run the test suite"
+}
+```
+
+### Reading your own session ID
+
+A client that wants to group its runs later needs the session ID it will be tagged with.
+Over stdio nothing in the transport carries it, so the server reports it in `get_info`:
+
+```json
+{
+  "currentContext": {
+    "workspace": "myproject",
+    "sessionId": "4ce5bfea-7ada-4b20-b59e-bcc0df500181"
+  }
+}
+```
+
+Call it once when you connect, keep the value, and query with it later:
+
+```shell
+flow logs --session 4ce5bfea-7ada-4b20-b59e-bcc0df500181
+```
+
+### What a session is
+
+**Whatever the caller says belongs together.** flow resolves it in this order:
+
+1. a per-connection ID from the transport, when one exists
+2. otherwise `FLOW_RUN_SESSION` from the environment — the caller told us
+3. otherwise a UUID minted once per `flow mcp` process
+
+Step 2 is what keeps a single conversation intact. An assistant does not only use MCP; it
+also shells out to `flow` directly. If the server invented an ID while the shell inherited a
+different one, the same conversation would land in two groups. A caller that tags its
+environment gets both paths under one ID.
+
+The minted UUID is a last resort, and it approximates a conversation rather than being one —
+a client that reconnects mid-conversation gets a new one. If you know your own conversation
+identity, supply it and flow will use it instead.
+
+## Everything else: three environment variables
+
+Runs that arrive any other way — an assistant shelling out, a script, an app embedding flow —
+would otherwise be indistinguishable from you typing at a prompt. flow reads provenance from
+the environment for **every** run, so anything that can export a variable can attribute itself:
+
+| Variable | Sets | Default |
+|---|---|---|
+| `FLOW_RUN_SOURCE` | `source` | `cli` |
+| `FLOW_RUN_CLIENT` | `clientName` | empty |
+| `FLOW_RUN_SESSION` | `sessionId` | empty |
+
+```shell
+FLOW_RUN_CLIENT=claude-code FLOW_RUN_SESSION=$MY_SESSION_ID flow run build
+```
+
+```shell
+flow logs --client claude-code    # finds it, even though source is still "cli"
+```
+
+Leaving `FLOW_RUN_SOURCE` alone is usually right: the run genuinely did arrive through the
+CLI, and `clientName` is what says an assistant drove it. Set it when the surface itself is
+distinct — a desktop app sets `desktop` so its runs are not confused with a terminal's.
+
+> **Export it, don't pass it.** Environment beats a flag the assistant must remember on every
+> call. A model can silently omit an argument; it cannot omit a variable it never sees. This
+> is also why identity is not a tool parameter — parameters are for intent, which only the
+> model knows.
+
+### Referencing another variable
+
+A session ID is only known once the assistant is running, so it cannot be written into a
+config file as a constant. Most harnesses store that file's values **verbatim** — no `${...}`
+interpolation — which would otherwise leave you recording a literal `${...}` on every run.
+
+So flow resolves the reference itself. Give it `${NAME}` and it reads `NAME` from the
+environment:
+
+```shell
+FLOW_RUN_SESSION='${MY_HARNESS_SESSION_ID}' flow run build
+# records the value of MY_HARNESS_SESSION_ID
+```
+
+If `NAME` is unset the session is recorded empty, never as the literal — one shared constant
+across every run would group unrelated work together, which is worse than recording nothing.
+
+### Example: an editor or agent harness
+
+Most agent tools let you define environment variables for the commands they run. Point flow at
+the variable the tool already exports for its own session:
+
+```json
+{
+  "env": {
+    "FLOW_RUN_CLIENT": "claude-code",
+    "FLOW_RUN_SESSION": "${CLAUDE_CODE_SESSION_ID}"
+  }
+}
+```
+
+That works whether or not the tool expands `${...}` itself — flow handles it either way. The
+variable's name lives in your config rather than in flow, so when a vendor renames theirs you
+edit one line here instead of waiting for a flow release.
+
+### Example: embedding flow behind a UI
+
+Set the variables on the process you spawn:
+
+```go
+cmd := exec.Command("flow", "run", "build")
+cmd.Env = append(os.Environ(),
+    "FLOW_RUN_SOURCE=desktop",
+    "FLOW_RUN_CLIENT=my-app",
+)
+```
+
+A wrapper that also runs an MCP server can set `FLOW_RUN_SESSION` on it too, and the server
+will use that instead of minting its own — so runs the assistant makes over MCP and runs the
+wrapper makes directly share one session.
+
+## What flow deliberately does not do
+
+**No client registry.** flow does not sniff for `CLAUDE_CODE_SESSION_ID`, `CURSOR_*`, or any
+other vendor's variables. Those are undocumented internals that get renamed, and detection
+built on them fails silently — history quietly stops grouping and nobody notices. Each tool
+maps its own variables onto the contract above; flow stays neutral.
+
+**No conversation identity of its own.** A session is a grouping key, not a claim about what a
+conversation is. flow will happily record a conversation ID you hand it — that is what step 2
+above is for — but it never goes looking for one, and it stores nothing that points back at a
+chat. When nobody supplies an identity, the minted per-process UUID is an approximation, and
+flow treats it as one. Deciding what a conversation *is* stays with the client, which is the
+only thing that can know.
+
+## Querying it
+
+```shell
+flow logs --source mcp                    # only assistant-launched runs
+flow logs --client cursor                 # one client
+flow logs --session <id>                  # one connection's runs
+flow logs --source mcp --status failed    # what an assistant broke
+```
+
+Assistants can review their own activity with `get_execution_logs`, which takes the same
+filters plus `mine: true` — scoped to the calling session without needing to know its ID.
+
+## What's Next?
+
+- [History & Logs](execution-history.md) — reading, filtering, and clearing history
+- [AI Tools](ai-tools.md) — setting up the MCP server

--- a/internal/mcp/command_executor.go
+++ b/internal/mcp/command_executor.go
@@ -45,6 +45,9 @@ const stdioSessionID = "stdio"
 // is stdio-only and each client spawns its own `flow mcp` process, so one process is exactly one
 // client connection — the session boundary mcp-go's constant fails to draw. It is resolved once
 // and never changes, which is what makes it a usable grouping key in execution history.
+//
+// It is the last resort: a caller that supplies its own identifier knows better than we do what
+// belongs together.
 var processSessionID = sync.OnceValue(uuid.NewString)
 
 // mcpProvenance builds run provenance for an MCP-originated command, capturing the calling client's
@@ -57,10 +60,21 @@ func mcpProvenance(ctx context.Context) runProvenance {
 			prov.Client = withInfo.GetClientInfo().Name
 		}
 	}
-	// Only substitute when the transport gave us nothing usable, so a transport that does issue
-	// genuine per-connection IDs keeps them.
+	// A transport that issues genuine per-connection IDs keeps them; only substitute when it
+	// gave us nothing usable.
 	if prov.Session == "" || prov.Session == stdioSessionID {
-		prov.Session = processSessionID()
+		// An inherited session beats one we invent. A harness that tags its environment wants
+		// the runs it makes over MCP grouped with the ones it makes by shelling out to the CLI
+		// — minting our own here would split a single conversation across two IDs.
+		if inherited := store.RunEnvValue(store.RunSessionEnv); inherited != "" {
+			prov.Session = inherited
+		} else {
+			prov.Session = processSessionID()
+		}
+	}
+	// Same reasoning for the client, for a transport that does not report one.
+	if prov.Client == "" {
+		prov.Client = store.RunEnvValue(store.RunClientEnv)
 	}
 	return prov
 }

--- a/internal/mcp/provenance_internal_test.go
+++ b/internal/mcp/provenance_internal_test.go
@@ -20,6 +20,22 @@ func (f fakeSession) NotificationChannel() chan<- mcp.JSONRPCNotification {
 }
 func (f fakeSession) SessionID() string { return f.id }
 
+// fakeSessionWithInfo also reports a client name, as a transport that completed the initialize
+// handshake does.
+type fakeSessionWithInfo struct {
+	fakeSession
+	name string
+}
+
+func (f fakeSessionWithInfo) GetClientInfo() mcp.Implementation {
+	return mcp.Implementation{Name: f.name}
+}
+func (f fakeSessionWithInfo) SetClientInfo(mcp.Implementation) {}
+func (f fakeSessionWithInfo) GetClientCapabilities() mcp.ClientCapabilities {
+	return mcp.ClientCapabilities{}
+}
+func (f fakeSessionWithInfo) SetClientCapabilities(mcp.ClientCapabilities) {}
+
 func TestMCPProvenance(t *testing.T) {
 	srv := server.NewMCPServer("test", "1.0.0")
 
@@ -37,6 +53,41 @@ func TestMCPProvenance(t *testing.T) {
 	t.Run("replaces an absent session ID", func(t *testing.T) {
 		if prov := mcpProvenance(context.Background()); prov.Session != processSessionID() {
 			t.Errorf("expected the process session ID, got %q", prov.Session)
+		}
+	})
+
+	t.Run("prefers an inherited session over one it mints", func(t *testing.T) {
+		// A harness that tags its environment wants its MCP runs grouped with the ones it
+		// makes by shelling out; minting our own would split one conversation across two IDs.
+		t.Setenv(store.RunSessionEnv, "harness-conversation-9")
+		ctx := srv.WithContext(context.Background(), fakeSession{id: stdioSessionID})
+		if prov := mcpProvenance(ctx); prov.Session != "harness-conversation-9" {
+			t.Errorf("expected the inherited session, got %q", prov.Session)
+		}
+	})
+
+	t.Run("resolves an inherited session given as a ${NAME} reference", func(t *testing.T) {
+		t.Setenv("HARNESS_SESSION_ID", "resolved-conversation")
+		t.Setenv(store.RunSessionEnv, "${HARNESS_SESSION_ID}")
+		if prov := mcpProvenance(context.Background()); prov.Session != "resolved-conversation" {
+			t.Errorf("expected the referenced value, got %q", prov.Session)
+		}
+	})
+
+	t.Run("falls back to the client the environment names", func(t *testing.T) {
+		t.Setenv(store.RunClientEnv, "some-harness")
+		// No transport session, so nothing reports a client name.
+		if prov := mcpProvenance(context.Background()); prov.Client != "some-harness" {
+			t.Errorf("expected the inherited client, got %q", prov.Client)
+		}
+	})
+
+	t.Run("keeps the transport's client over the environment's", func(t *testing.T) {
+		t.Setenv(store.RunClientEnv, "stale-value")
+		sess := fakeSessionWithInfo{fakeSession: fakeSession{id: "real-7"}, name: "cursor"}
+		ctx := srv.WithContext(context.Background(), sess)
+		if prov := mcpProvenance(ctx); prov.Client != "cursor" {
+			t.Errorf("expected the transport's client, got %q", prov.Client)
 		}
 	})
 

--- a/internal/runner/engine/engine.go
+++ b/internal/runner/engine/engine.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"golang.org/x/sync/errgroup"
@@ -28,6 +29,18 @@ func (rs ResultSummary) HasErrors() bool {
 		}
 	}
 	return false
+}
+
+// Err returns the failures as one error, naming the executable behind each, or nil when
+// everything succeeded.
+func (rs ResultSummary) Err() error {
+	var errs []error
+	for _, r := range rs.Results {
+		if r.Error != nil {
+			errs = append(errs, fmt.Errorf("%s: %w", r.ID, r.Error))
+		}
+	}
+	return errors.Join(errs...)
 }
 
 func (rs ResultSummary) String() string {

--- a/internal/runner/parallel/parallel.go
+++ b/internal/runner/parallel/parallel.go
@@ -288,7 +288,7 @@ func handleExec(
 		}
 	}
 	if results.HasErrors() {
-		return fmt.Errorf("parallel execution failed")
+		return errors.Wrap(results.Err(), "parallel execution failed")
 	}
 	return nil
 }

--- a/internal/runner/serial/serial.go
+++ b/internal/runner/serial/serial.go
@@ -268,7 +268,7 @@ func handleExec(
 		}
 	}
 	if results.HasErrors() {
-		return fmt.Errorf("serial execution failed")
+		return errors.Wrap(results.Err(), "serial execution failed")
 	}
 	return nil
 }

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -30,7 +30,7 @@ type Context struct {
 	ctx                   context.Context
 	cancelFunc            context.CancelFunc
 	stdOut, stdIn, stdErr *os.File
-	callbacks             []func(*Context) error
+	callbacks             *callbackList
 	tuiOnce               sync.Once
 	tuiContainer          *tuikit.Container
 
@@ -107,6 +107,7 @@ func NewContext(ctx context.Context, cancelFunc context.CancelFunc, opts ...Opti
 
 	c := &Context{
 		appName:          "flow",
+		callbacks:        &callbackList{},
 		ctx:              ctx,
 		cancelFunc:       cancelFunc,
 		stdOut:           os.Stdout,
@@ -131,7 +132,10 @@ func NewContext(ctx context.Context, cancelFunc context.CancelFunc, opts ...Opti
 // fields (CurrentTask, ProcessTmpDir, etc.)
 func (ctx *Context) ShallowCopy() *Context {
 	cp := &Context{
-		appName:          ctx.appName,
+		appName: ctx.appName,
+		// Shared, not copied: cleanup registered by a parallel branch running on this copy
+		// must reach the root's Finalize. Copying the slice dropped it on the floor.
+		callbacks:        ctx.callbacks,
 		ctx:              ctx.ctx,
 		cancelFunc:       ctx.cancelFunc,
 		stdOut:           ctx.stdOut,
@@ -281,18 +285,50 @@ func (ctx *Context) SetView(view tuikit.View) error {
 	return ctx.TUIContainer().SetView(view)
 }
 
+// callbackList collects deferred cleanup registered on a context and on every shallow copy of
+// it. Copies share one list by pointer, because a copy is what gets handed to a parallel
+// branch: cleanup registered in there (temporary env files, for one) has to survive back to
+// whoever finalizes the root. Guarded, since those branches register concurrently.
+type callbackList struct {
+	mu    sync.Mutex
+	funcs []func(*Context) error
+}
+
+func (l *callbackList) add(callback func(*Context) error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.funcs = append(l.funcs, callback)
+}
+
+// drain returns the registered callbacks and empties the list, so finalizing more than once
+// cannot run the same cleanup twice.
+func (l *callbackList) drain() []func(*Context) error {
+	if l == nil {
+		return nil
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	funcs := l.funcs
+	l.funcs = nil
+	return funcs
+}
+
 func (ctx *Context) AddCallback(callback func(*Context) error) {
 	if callback == nil {
 		return
 	}
-	ctx.callbacks = append(ctx.callbacks, callback)
+	if ctx.callbacks == nil {
+		// Only reachable for a hand-built Context; NewContext and ShallowCopy both set it.
+		ctx.callbacks = &callbackList{}
+	}
+	ctx.callbacks.add(callback)
 }
 
 func (ctx *Context) Finalize() {
 	_ = ctx.stdIn.Close()
 	_ = ctx.stdOut.Close()
 
-	for _, cb := range ctx.callbacks {
+	for _, cb := range ctx.callbacks.drain() {
 		if err := cb(ctx); err != nil {
 			logger.Log().WrapError(err, "callback execution error")
 		}

--- a/pkg/context/context_test.go
+++ b/pkg/context/context_test.go
@@ -4,6 +4,7 @@ package context
 import (
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 
 	"charm.land/lipgloss/v2"
@@ -101,4 +102,60 @@ var _ = ginkgo.Describe("Context", func() {
 
 func strPtr(s string) *string {
 	return &s
+}
+
+func TestCallbacksSurviveShallowCopy(t *testing.T) {
+	t.Run("a copy's callbacks reach the original", func(t *testing.T) {
+		// A parallel branch runs on a shallow copy. Cleanup it registers — temporary env
+		// files, for one — used to land on the copy and never run, because only the root
+		// context is ever finalized.
+		root := &Context{callbacks: &callbackList{}}
+		var ran []string
+
+		root.AddCallback(func(*Context) error { ran = append(ran, "root"); return nil })
+		branch := root.ShallowCopy()
+		branch.AddCallback(func(*Context) error { ran = append(ran, "branch"); return nil })
+
+		for _, cb := range root.callbacks.drain() {
+			_ = cb(root)
+		}
+
+		if len(ran) != 2 {
+			t.Fatalf("expected both callbacks to run, got %v", ran)
+		}
+	})
+
+	t.Run("draining twice does not run cleanup twice", func(t *testing.T) {
+		root := &Context{callbacks: &callbackList{}}
+		count := 0
+		root.AddCallback(func(*Context) error { count++; return nil })
+
+		for range 2 {
+			for _, cb := range root.callbacks.drain() {
+				_ = cb(root)
+			}
+		}
+
+		if count != 1 {
+			t.Errorf("expected the callback to run once, ran %d times", count)
+		}
+	})
+
+	t.Run("concurrent branches can register at once", func(t *testing.T) {
+		// Run with -race: parallel branches register from their own goroutines.
+		root := &Context{callbacks: &callbackList{}}
+		var wg sync.WaitGroup
+		for range 32 {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				root.ShallowCopy().AddCallback(func(*Context) error { return nil })
+			}()
+		}
+		wg.Wait()
+
+		if got := len(root.callbacks.drain()); got != 32 {
+			t.Errorf("expected 32 callbacks, got %d", got)
+		}
+	})
 }

--- a/pkg/store/provenance_test.go
+++ b/pkg/store/provenance_test.go
@@ -1,0 +1,50 @@
+package store_test
+
+import (
+	"testing"
+
+	"github.com/flowexec/flow/v2/pkg/store"
+)
+
+func TestRunEnvValue(t *testing.T) {
+	t.Run("returns a plain value unchanged", func(t *testing.T) {
+		t.Setenv(store.RunClientEnv, "claude-code")
+		if got := store.RunEnvValue(store.RunClientEnv); got != "claude-code" {
+			t.Errorf("expected %q, got %q", "claude-code", got)
+		}
+	})
+
+	t.Run("resolves a ${NAME} reference from the environment", func(t *testing.T) {
+		// A harness that cannot interpolate its settings file stores the reference verbatim.
+		t.Setenv("HARNESS_SESSION_ID", "3f9a-conversation")
+		t.Setenv(store.RunSessionEnv, "${HARNESS_SESSION_ID}")
+		if got := store.RunEnvValue(store.RunSessionEnv); got != "3f9a-conversation" {
+			t.Errorf("expected the referenced value, got %q", got)
+		}
+	})
+
+	t.Run("yields empty when the reference points at nothing", func(t *testing.T) {
+		// Never the literal: a constant `${...}` on every run would group unrelated runs
+		// together, which is worse than recording no session at all.
+		t.Setenv(store.RunSessionEnv, "${NOT_SET_ANYWHERE}")
+		if got := store.RunEnvValue(store.RunSessionEnv); got != "" {
+			t.Errorf("expected empty, got %q", got)
+		}
+	})
+
+	t.Run("leaves values that only look like references alone", func(t *testing.T) {
+		for _, value := range []string{"${}", "$NAME", "{NAME}", "prefix-${NAME}", "${NAME}-suffix"} {
+			t.Setenv(store.RunSessionEnv, value)
+			if got := store.RunEnvValue(store.RunSessionEnv); got != value {
+				t.Errorf("expected %q unchanged, got %q", value, got)
+			}
+		}
+	})
+
+	t.Run("is empty when the variable is unset", func(t *testing.T) {
+		t.Setenv(store.RunSessionEnv, "")
+		if got := store.RunEnvValue(store.RunSessionEnv); got != "" {
+			t.Errorf("expected empty, got %q", got)
+		}
+	})
+}

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -87,6 +87,35 @@ type DataStore interface { //nolint:interfacebloat // single backing store with 
 	Close() error
 }
 
+// RunEnvValue reads a provenance environment variable, resolving a `${NAME}` value by looking
+// NAME up in the environment.
+//
+// Agent harnesses commonly let you set a static environment value but not interpolate one —
+// their settings file stores what you write verbatim. Without this, mapping a harness's own
+// session variable onto RunSessionEnv would record the literal `${...}` on every run: a
+// constant masquerading as an identity, silently grouping unrelated runs together. That is a
+// worse failure than having no session at all, because the grouping looks like it worked.
+//
+// Resolving here rather than recognizing specific variables keeps flow neutral: the name of
+// the harness's variable lives in that harness's config, where it can be corrected when the
+// vendor renames it. An unresolvable reference yields empty, since no identity beats a false one.
+func RunEnvValue(key string) string {
+	value := os.Getenv(key)
+	if name, ok := envReference(value); ok {
+		return os.Getenv(name)
+	}
+	return value
+}
+
+// envReference reports whether a value is a `${NAME}` reference and the name it points at.
+func envReference(value string) (string, bool) {
+	if !strings.HasPrefix(value, "${") || !strings.HasSuffix(value, "}") {
+		return "", false
+	}
+	name := strings.TrimSuffix(strings.TrimPrefix(value, "${"), "}")
+	return name, name != ""
+}
+
 // RunStatus represents the lifecycle state of an execution record.
 type RunStatus string
 


### PR DESCRIPTION
## Summary
- Report nested serial/parallel exec errors properly instead of swallowing them
- Surface run provenance (workspace, executable, session) as first-class env vars available to executables, with supporting docs and MCP command-executor plumbing

## Test plan
- [ ] `flow validate` (generate → lint → test → generated-diff check)